### PR TITLE
fix(ReferenceTooltips.js): fix spread syntax

### DIFF
--- a/src/gadgets/ReferenceTooltips/MediaWiki:Gadget-ReferenceTooltips.js
+++ b/src/gadgets/ReferenceTooltips/MediaWiki:Gadget-ReferenceTooltips.js
@@ -819,7 +819,7 @@
                 let returnValue, currentTooltip = this;
 
                 do {
-                    returnValue = func.apply(currentTooltip)(currentTooltip, parameters);
+                    returnValue = func.apply(currentTooltip, parameters);
                     if (stopAtTrue && returnValue) {
                         break;
                     }

--- a/src/gadgets/ReferenceTooltips/MediaWiki:Gadget-ReferenceTooltips.js
+++ b/src/gadgets/ReferenceTooltips/MediaWiki:Gadget-ReferenceTooltips.js
@@ -819,7 +819,7 @@
                 let returnValue, currentTooltip = this;
 
                 do {
-                    returnValue = func.bind(currentTooltip)(currentTooltip, ...(parameters ?? []));
+                    returnValue = func.bind(currentTooltip)(currentTooltip, ...parameters ?? []);
                     if (stopAtTrue && returnValue) {
                         break;
                     }

--- a/src/gadgets/ReferenceTooltips/MediaWiki:Gadget-ReferenceTooltips.js
+++ b/src/gadgets/ReferenceTooltips/MediaWiki:Gadget-ReferenceTooltips.js
@@ -819,7 +819,7 @@
                 let returnValue, currentTooltip = this;
 
                 do {
-                    returnValue = func.apply(currentTooltip, parameters);
+                    returnValue = func.bind(currentTooltip)(currentTooltip, ...(parameters ?? []));
                     if (stopAtTrue && returnValue) {
                         break;
                     }

--- a/src/gadgets/ReferenceTooltips/MediaWiki:Gadget-ReferenceTooltips.js
+++ b/src/gadgets/ReferenceTooltips/MediaWiki:Gadget-ReferenceTooltips.js
@@ -819,7 +819,7 @@
                 let returnValue, currentTooltip = this;
 
                 do {
-                    returnValue = func.bind(currentTooltip)(currentTooltip, ...parameters);
+                    returnValue = func.apply(currentTooltip)(currentTooltip, parameters);
                     if (stopAtTrue && returnValue) {
                         break;
                     }


### PR DESCRIPTION
Spread syntax throws an error with undefined.