### PR TITLE
fix(Gadget-mobile-styles.css): ol on small screens

### DIFF
--- a/src/gadgets/mobile-styles/MediaWiki:Gadget-mobile-styles.css
+++ b/src/gadgets/mobile-styles/MediaWiki:Gadget-mobile-styles.css
@@ -411,6 +411,7 @@ html>body.skin-minerva .content {
 /* 修复列表对齐问题 */
 html>body.skin-minerva .content ol {
     list-style-position: outside;
+    padding-left: 2.25em;
 }
 
 /* 修复广告和侧边栏均z-index为0的问题 */


### PR DESCRIPTION
On a small screen, ol numbers will be partly invisible. See [this special page](https://mzh.moegirl.org.cn/Special:%E7%9F%AD%E9%A1%B5%E9%9D%A2) as an example.

The padding of 2.25em is used in [MinervaNeue](https://github.com/wikimedia/mediawiki-skins-MinervaNeue/blob/1a2960a3c0129f3cd3e9754802c4272d240862e5/resources/skins.minerva.base.styles/content/lists.less#L3).