### PR TITLE
fix(mobile-styles): conflict with margin-left-set

### DIFF
--- a/src/gadgets/mobile-styles/MediaWiki:Gadget-mobile-styles.css
+++ b/src/gadgets/mobile-styles/MediaWiki:Gadget-mobile-styles.css
@@ -411,6 +411,8 @@ html>body.skin-minerva .content {
 /* 修复列表对齐问题 */
 html>body.skin-minerva .content ol {
     list-style-position: outside;
+}
+html>body.skin-minerva .content ol:not(.margin-left-set) {
     padding-left: 2.25em;
 }
 

--- a/src/gadgets/mobile-styles/MediaWiki:Gadget-mobile-styles.css
+++ b/src/gadgets/mobile-styles/MediaWiki:Gadget-mobile-styles.css
@@ -412,6 +412,7 @@ html>body.skin-minerva .content {
 html>body.skin-minerva .content ol {
     list-style-position: outside;
 }
+
 html>body.skin-minerva .content ol:not(.margin-left-set) {
     padding-left: 2.25em;
 }


### PR DESCRIPTION
My previous pull request (#49) did not consider the `margin-left-set` class added by [gadget-site-js.js](/MoegirlPediaInterfaceAdmins/MoegirlPediaInterfaceCodes/blob/master/src/gadgets/site-js/MediaWiki:Gadget-site-js.js#L337). This commit will fix the conflict by ignoring those ordered lists with a nonzero margin-left. 