### PR TITLE
fix(Moeskin.js): configurable addPortletLink

### DIFF
--- a/src/global/MediaWiki:Moeskin.js
+++ b/src/global/MediaWiki:Moeskin.js
@@ -79,9 +79,11 @@
         Object.defineProperties(window, {
             addPortletLink: {
                 value: addPortletLink,
+                configurable: true,
             },
             useCustomSidenavBlock: {
                 value: useCustomSidenavBlock,
+                configurable: true,
             },
         });
     } catch (e) {
@@ -90,6 +92,7 @@
     await mw.loader.using(["mediawiki.util"]);
     Reflect.defineProperty(mw.util, "addPortletLink", {
         value: addPortletLink,
+        configurable: true,
     });
     mw.hook("moeskin.addPortletLink").fire({ addPortletLink, useCustomSidenavBlock });
     /* PageTools */


### PR DESCRIPTION
解决[Moeskin.js](/MoegirlPediaInterfaceAdmins/MoegirlPediaInterfaceCodes/blob/master/src/global/MediaWiki:Moeskin.js#L79)与[Gadget-site-lib.js](/MoegirlPediaInterfaceAdmins/MoegirlPediaInterfaceCodes/blob/master/src/gadgets/site-lib/MediaWiki:Gadget-site-lib.js#L29)间的冲突。