### PR TITLE
add jQuery UI dependency

### DIFF
--- a/src/gadgets/UserMessages/definition.json
+++ b/src/gadgets/UserMessages/definition.json
@@ -15,6 +15,7 @@
     "dependencies": [
         "ext.gadget.site-lib",
         "ext.gadget.libUtil",
+        "ext.gadget.jquery.ui",
         "mediawiki.util"
     ],
     "_section": "maintenance"


### PR DESCRIPTION
近期该小工具无法正常调用jquery.ui，代码太长难以统计用了多少组件，直接调用整库