### PR TITLE
fix(Moeskin.js): fix a few image issues

### DIFF
--- a/src/global/MediaWiki:Moeskin.js
+++ b/src/global/MediaWiki:Moeskin.js
@@ -57,16 +57,10 @@
         if (mw.loader.getState("mediawiki.page.gallery.slideshow") === "ready") {
             const {getImageInfo} = mw.GallerySlideshow.prototype;
             mw.GallerySlideshow.prototype.getImageInfo = function($img) {
-                const {imageInfoCache} = this;
-                return $.when("undefined" in imageInfoCache
-                    ? imageInfoCache.undefined.then((info) => {
-                        imageInfoCache[info.thumburl] ||= imageInfoCache.undefined;
-                        delete imageInfoCache.undefined;
-                    })
-                    : true,
-                ).then(() => {
-                    return getImageInfo.call(this, $img);
-                });
+                if ($img.attr("src") === undefined) {
+                    $img.attr("src", $img.data("lazy-src"));
+                }
+                return getImageInfo.call(this, $img);
             };
             $("li.gallerycarousel").remove();
             mw.util.$content.find(".mw-gallery-slideshow").each(function() {

--- a/src/global/MediaWiki:Moeskin.js
+++ b/src/global/MediaWiki:Moeskin.js
@@ -54,7 +54,8 @@
             }
             return null;
         };
-        $.proxy(mw.mmv.bootstrap, "processThumbs")(mw.util.$content);
+        
+        /* gallery-slideshow */
         if (mw.loader.getState("mediawiki.page.gallery.slideshow") === "ready") {
             const {getImageInfo} = mw.GallerySlideshow.prototype;
             mw.GallerySlideshow.prototype.getImageInfo = function($img) {
@@ -68,6 +69,10 @@
                 new mw.GallerySlideshow(this);
             });
         }
+        
+        /* MultiMediaViewer */
+        await mw.loader.using("mmv.bootstrap");
+        $.proxy(mw.mmv.bootstrap, "processThumbs")(mw.util.$content);
     }
 
     /* polyfill */

--- a/src/global/MediaWiki:Moeskin.js
+++ b/src/global/MediaWiki:Moeskin.js
@@ -55,6 +55,19 @@
         };
         $.proxy(mw.mmv.bootstrap, "processThumbs")(mw.util.$content);
         if (mw.loader.getState("mediawiki.page.gallery.slideshow") === "ready") {
+            const {getImageInfo} = mw.GallerySlideshow.prototype;
+            mw.GallerySlideshow.prototype.getImageInfo = function($img) {
+                const {imageInfoCache} = this;
+                return $.when("undefined" in imageInfoCache
+                    ? imageInfoCache.undefined.then((info) => {
+                        imageInfoCache[info.thumburl] ||= imageInfoCache.undefined;
+                        delete imageInfoCache.undefined;
+                    })
+                    : true,
+                ).then(() => {
+                    return getImageInfo.call(this, $img);
+                });
+            };
             $("li.gallerycarousel").remove();
             mw.util.$content.find(".mw-gallery-slideshow").each(function() {
                 new mw.GallerySlideshow(this);


### PR DESCRIPTION
[讨论版](https://zh.moegirl.org.cn/萌娘百科_talk:讨论版/技术实现#萌皮图像显示形式有差异)上提到的关于`<gallery mode="slideshow">`的bug严重妨碍了条目的正常阅读，但遗憾的是迟迟未得到运营的回应。因此尝试通过站内JS临时修复，并顺便修复讨论版上新提出的[关于MultiMediaViewer的bug](https://zh.moegirl.org.cn/萌娘百科_talk:讨论版/技术实现#MoeSkin查看大图的问题)。