### PR TITLE
revert(target.js): switch back to jsdelivr

### DIFF
--- a/scripts/prefetch/targets.js
+++ b/scripts/prefetch/targets.js
@@ -5,7 +5,7 @@
 module.exports = [
     {
         name: "wikiplus-highlight",
-        url: "https://unpkg.com/wikiplus-highlight/dist/main.min.js",
+        url: "https://cdn.jsdelivr.net/npm/wikiplus-highlight",
         file: "src/gadgets/wikiplus-highlight/MediaWiki:Gadget-wikiplus-highlight.js",
     },
     {


### PR DESCRIPTION
连续几天GitHub Actions都无法正常从unpkg.com下载脚本，所以请求重新改回jsdelivr。

revert 61541c4203f17684c6dcdbd55c4fe5acef252c1b