### PR TITLE
fix(Moeskin.js): fix MultiMediaViewer module name

### DIFF
--- a/src/global/MediaWiki:Moeskin.js
+++ b/src/global/MediaWiki:Moeskin.js
@@ -71,7 +71,7 @@
         }
         
         /* MultiMediaViewer */
-        if (mw.config.get("wgMediaViewerOnClick") && ["loading", "loaded", "executing", "ready", "error"].includes(mw.loader.getState("mmv.bootstrap.autostart"))) {
+        if (mw.config.get("wgMediaViewerOnClick") && ["loading", "loaded", "executing", "ready"].includes(mw.loader.getState("mmv.bootstrap.autostart"))) {
             await mw.loader.using("mmv.bootstrap.autostart");
             $.proxy(mw.mmv.bootstrap, "processThumbs")(mw.util.$content);
         }

--- a/src/global/MediaWiki:Moeskin.js
+++ b/src/global/MediaWiki:Moeskin.js
@@ -71,8 +71,8 @@
         }
         
         /* MultiMediaViewer */
-        if (mw.config.get("wgMediaViewerOnClick")) {
-            await mw.loader.using("mmv.bootstrap");
+        if (mw.config.get("wgMediaViewerOnClick") && ["loading", "loaded", "executing", "ready", "error"].includes(mw.loader.getState("mmv.bootstrap.autostart"))) {
+            await mw.loader.using("mmv.bootstrap.autostart");
             $.proxy(mw.mmv.bootstrap, "processThumbs")(mw.util.$content);
         }
     }


### PR DESCRIPTION
不是致命错误，但每次控制台都会报错也挺难受的。万一以后哪天同时有一个真bug发生可能会造成debug时的困扰。另外如果不介意让所有启用媒体查看器的用户（包括所有匿名用户）都在每个页面加载一次`mmv.bootstrap.autostart`模块的话，第74行可以不改。