### PR TITLE
修复和信息栏2.0的兼容问题

### DIFF
--- a/src/gadgets/site-styles/MediaWiki:Gadget-site-styles.css
+++ b/src/gadgets/site-styles/MediaWiki:Gadget-site-styles.css
@@ -203,7 +203,7 @@
 
 .Tabs.AutoWidth {
     width: max-content;
-    display: flow-root;
+    display: table-cell;
 }
 
 .Tabs.FloatLeft {


### PR DESCRIPTION
信息栏2.0后面的{{tabs}}使用AutoWidth=yes会清除浮动（Special:固定链接/6690073），不用则会出现多余白底盖住信息栏。此法解决前后效果差见Special:diff/6690115。