### PR TITLE
修复img的height属性不生效的问题

### DIFF
--- a/src/gadgets/moeskin-styles/MediaWiki:Gadget-moeskin-styles.css
+++ b/src/gadgets/moeskin-styles/MediaWiki:Gadget-moeskin-styles.css
@@ -149,7 +149,7 @@ aside#moe-global-siderail #moe-custom-sidenav-block h2 {
 }
 
 /* @fix 临时修复 img 元素的宽高 */
-img {
+img:not([height]) {
     height: auto;
 }
 


### PR DESCRIPTION
<img height="" />
height属性被覆盖