### PR TITLE
feat(wikiBlame): use more efficient api to reduce server load

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -15,3 +15,4 @@ Bhsd <2545473905@qq.com>
 Honoka55 <1915637207@qq.com>
 BearBin <bearbin1215@qq.com>
 鬼影233 <82418456+gui-ying233@users.noreply.github.com>
+Lihaohong <lihaohong6@gmail.com>


### PR DESCRIPTION
使用`action=query`且`prop=revisions`获取条目的历史版本时顺便获取wikitext以减少对服务器的负担。

例如，如果条目有100个版本，其中有2个添加了指定的文字，原本的做法是提交1个请求获取`revisions`，再提交100次`compare`请求。

更新后会先提交100/50=2个请求获取所有历史版本及其源代码，再判断哪些版本的源代码添加了指定的文字，最后再使用`compare`对比找到的2个版本。

这个算法的问题在于如果指定文字多次出现（例如，从出现1次到出现2次），则不会触发程序的判断，尽管mw自带的`compare`可以发现。但是和性能的大幅提高比起来，这个问题可以忽略。
