### PR TITLE
fix(mailmapChecker): use console.error to print error message

### DIFF
--- a/scripts/mailmapChecker/index.js
+++ b/scripts/mailmapChecker/index.js
@@ -55,7 +55,7 @@ if (isInGithubActions) {
         console.info("All the emails are in .mailmap, exit.");
         exit(0);
     }
-    console("Found emails not in .mailmap, please add it:", failures);
+    console.error("Found emails not in .mailmap, please add it:", failures);
     exit(1);
 } else {
     const failures = [];


### PR DESCRIPTION
修一下mailmapChecker的一个小bug