### PR TITLE
fix: 临时修复svg缩略图损坏

### DIFF
--- a/src/gadgets/site-js/MediaWiki:Gadget-site-js.js
+++ b/src/gadgets/site-js/MediaWiki:Gadget-site-js.js
@@ -589,17 +589,18 @@
         }
     }
     // 临时修复svg缩略图损坏
-    $('img[srcset*=".svg"]').each(function() {
-        $(this).attr("src", $(this).attr("src").replaceAll("thumb/", "").replaceAll(/\.svg\/.*/g, ".svg"));
-        $(this).attr("srcset", $(this).attr("srcset").replaceAll("thumb/", "").replaceAll(/\.svg\/[^ ]*/g, ".svg"));
-    });
-    $("img[data-lazy-src*='.svg']").each(function () {
-        $(this)
-            .attr("src", $(this).attr("data-lazy-src").replaceAll("thumb/", "").replaceAll(/\.svg\/.*/g, ".svg"))
-            .attr("srcset", $(this).attr("data-lazy-srcset")?.replaceAll("thumb/", "").replaceAll(/\.svg\/[^ ]*/g, ".svg"))
-            .removeAttr("data-lazy-state");
-        $(this).replaceWith($(this).clone());
-    });
+    /**
+     * @type { NodeListOf<HTMLImageElement> }
+     */
+    const svgs = document.querySelectorAll('img[src$=".svg.png"]');
+    for (const img of svgs) {
+        img.src = img.src.replace("/thumb/", "/").replace(/\.svg\/[^/]+\.svg\.png$/, ".svg");
+        img.removeAttribute("srcset");
+        img.removeAttribute("data-lazy-src");
+        img.removeAttribute("data-lazy-srcset");
+        img.removeAttribute("data-lazy-state");
+        img.classList.remove("lazyload");
+    }
     $window.triggerHandler("resize");
     $window.on("load", () => {
         $window.triggerHandler("resize");

--- a/src/gadgets/site-js/MediaWiki:Gadget-site-js.js
+++ b/src/gadgets/site-js/MediaWiki:Gadget-site-js.js
@@ -588,6 +588,18 @@
             }
         }
     }
+    // 临时修复svg缩略图损坏
+    $('img[srcset*=".svg"]').each(function() {
+        $(this).attr("src", $(this).attr("src").replaceAll("thumb/", "").replaceAll(/\.svg\/.*/g, ".svg"));
+        $(this).attr("srcset", $(this).attr("srcset").replaceAll("thumb/", "").replaceAll(/\.svg\/[^ ]*/g, ".svg"));
+    });
+    $("img[data-lazy-src*='.svg']").each(function () {
+        $(this)
+            .attr("src", $(this).attr("data-lazy-src").replaceAll("thumb/", "").replaceAll(/\.svg\/.*/g, ".svg"))
+            .attr("srcset", $(this).attr("data-lazy-srcset")?.replaceAll("thumb/", "").replaceAll(/\.svg\/[^ ]*/g, ".svg"))
+            .removeAttr("data-lazy-state");
+        $(this).replaceWith($(this).clone());
+    });
     $window.triggerHandler("resize");
     $window.on("load", () => {
         $window.triggerHandler("resize");

--- a/src/gadgets/site-js/MediaWiki:Gadget-site-js.js
+++ b/src/gadgets/site-js/MediaWiki:Gadget-site-js.js
@@ -600,6 +600,8 @@
         img.removeAttribute("data-lazy-srcset");
         img.removeAttribute("data-lazy-state");
         img.classList.remove("lazyload");
+        img.after(img.cloneNode(deep));
+        img.remove();
     }
     $window.triggerHandler("resize");
     $window.on("load", () => {

--- a/src/gadgets/site-js/MediaWiki:Gadget-site-js.js
+++ b/src/gadgets/site-js/MediaWiki:Gadget-site-js.js
@@ -600,7 +600,7 @@
         img.removeAttribute("data-lazy-srcset");
         img.removeAttribute("data-lazy-state");
         img.classList.remove("lazyload");
-        img.after(img.cloneNode(deep));
+        img.after(img.cloneNode(true));
         img.remove();
     }
     $window.triggerHandler("resize");


### PR DESCRIPTION
大概能有更优雅的方法，不过这个目前测试了挺多天没出现过问题，能用就不改了。
理论上应该只有直接使用`<img />`标签然后还带`srcset`属性并且图片url内有`thumb/`或`.svg/`才会出现问题。