### PR TITLE
site-styles: Remove the unused rule about file description

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -19,3 +19,4 @@ BearBin <bearbin1215@qq.com>
 鬼影233 <82418456+gui-ying233@users.noreply.github.com>
 Lihaohong <12545295+syccxcc@users.noreply.github.com>
 BearBin <20369414+BearBin1215@users.noreply.github.com>
+Func <Funcer@outlook.com>

--- a/src/gadgets/site-styles/MediaWiki:Gadget-site-styles.css
+++ b/src/gadgets/site-styles/MediaWiki:Gadget-site-styles.css
@@ -468,11 +468,6 @@ body .ajaxpoll {
     min-width: 400px;
 }
 
-/* 隐藏文件说明302 */
-.ns-6 #shared-image-desc {
-    display: none;
-}
-
 /* 侧边栏底图默认隐藏（通过小工具显示） */
 .sidebar-character {
     display: none;


### PR DESCRIPTION
The shared file description feature has been disabled from the server side, so this rule is unused.

I think it should be enabled though, since nowadays file descriptions are generally proper enough.