### PR TITLE
fix(vector-styles): Replace z-index hack of the top blue border

### DIFF
--- a/src/gadgets/vector-styles/MediaWiki:Gadget-vector-styles.css
+++ b/src/gadgets/vector-styles/MediaWiki:Gadget-vector-styles.css
@@ -11,13 +11,9 @@ body.skin-vector {
 }
 
 /* 侧边栏、顶部栏 */
-#content {
+#mw-head-base {
+    border-bottom: 1px solid #a7d7f9;
     position: relative;
-    z-index: 7;
-}
-
-#mw-navigation div.vectorMenu div.menu {
-    z-index: 9;
 }
 
 #mw-panel #p-logo {


### PR DESCRIPTION
As far as I can recall, the first z-index change on `#content` was for the top blue border to overlap the white background of the left and right navigation bars. The second one was the workaround for navigation bars and dropdowns affected by the first one to display and be clickable.

Site styles and even extensions are not supposed to change the z-index of content containers, while MediaWiki core defined `@z-index-above-content: 1;`.

Let's replace the hack with a cleaner solution by applying the bottom border on the `#mw-head-base` element.