### PR TITLE
Update MediaWiki:Gadget-wikieditor-highlight.js

### DIFF
--- a/src/gadgets/wikieditor-highlight/MediaWiki:Gadget-wikieditor-highlight.js
+++ b/src/gadgets/wikieditor-highlight/MediaWiki:Gadget-wikieditor-highlight.js
@@ -27,13 +27,12 @@
         cm.prefer([
             "highlightSpecialChars",
             "highlightActiveLine",
-            "highlightWhitespace",
             "bracketMatching",
             "closeBrackets",
         ]);
         const [config] = await Promise.all([
             libCachedCode.getCachedCode("https://testingcf.jsdelivr.net/npm/wikiparser-node/config/moegirl.json"),
-            cm.defaultLint(true, { include: ns === 10 }),
+            cm.defaultLint(true, { include: [2, 10, 828].includes(ns) }),
         ]);
         try {
             window.wikiparse?.setConfig(JSON.parse(config));


### PR DESCRIPTION
根据用户反馈，不再默认启用highlightWhitespace扩展