### PR TITLE
fix(wikieditor-highlight): 适配MoeSkin

### DIFF
--- a/src/gadgets/wikieditor-highlight/MediaWiki:Gadget-wikieditor-highlight.css
+++ b/src/gadgets/wikieditor-highlight/MediaWiki:Gadget-wikieditor-highlight.css
@@ -1,0 +1,9 @@
+/* TODO: MW升级后WikiEditor扩展自带这条样式 */
+.wikiEditor-ui-toolbar {
+	z-index: 7;
+}
+
+/* 修复MoeSkin */
+#mw-content-text .cm-panel-lint > ul {
+	margin-left: 0;
+}

--- a/src/gadgets/wikieditor-highlight/MediaWiki:Gadget-wikieditor-highlight.js
+++ b/src/gadgets/wikieditor-highlight/MediaWiki:Gadget-wikieditor-highlight.js
@@ -4,7 +4,6 @@
     if (!["edit", "submit"].includes(mw.config.get("wgAction")) || mw.config.get("wgPageContentModel") !== "wikitext") {
         return;
     }
-    mw.loader.addStyleTag(".wikiEditor-ui-toolbar{z-index:7}");
     await $.ready;
 
     const localObjectStorage = new LocalObjectStorage("wikieditor-highlight");

--- a/src/gadgets/wikieditor-highlight/definition.yaml
+++ b/src/gadgets/wikieditor-highlight/definition.yaml
@@ -34,3 +34,4 @@ _section: editing
 
 _files:
   - MediaWiki:Gadget-wikieditor-highlight.js
+  - MediaWiki:Gadget-wikieditor-highlight.css


### PR DESCRIPTION
为了方便以后管理和添加更多样式，还是单独建了个CSS页面