### PR TITLE
fix(Gadget/SideBarPic): :bug: 修复dark模式颜色错误

### DIFF
--- a/src/gadgets/SideBarPic/MediaWiki:Gadget-SideBarPic.css
+++ b/src/gadgets/SideBarPic/MediaWiki:Gadget-SideBarPic.css
@@ -18,7 +18,6 @@ body.sideBarPic-executed #wglogo {
 }
 
 @media screen and (width <= 600px) {
-
     /* 低像素设备隐藏 */
     .sidebar-character {
         display: none !important;
@@ -56,14 +55,5 @@ body.sideBarPic:not(.DeceasedPerson) #footer {
 }
 
 body.sideBarPic:not(.DeceasedPerson) #footer #footer-moegirl .copyright {
-    color: #2F2F2F;
-}
-
-/* For Skin:MoeSkin 机智的小鱼君 2022年4月16日 */
-body.sideBarPic-executed.skin-moeskin #moe-global-footer {
-    z-index: 1;
-}
-
-body.sideBarPic-executed.skin-moeskin #moe-main-container {
-    --theme-card-background-color: rgb(255 255 255 / 90%);
+    color: #2f2f2f;
 }


### PR DESCRIPTION
此两 CSS 已经由 MoeSkin 本身修复，不再需要且会导致 dark 模式颜色错误