### PR TITLE
fix(Gadget/moeskin-styles): :bug: 萌皮移动版下class=navbox的表格显示错位

### DIFF
--- a/src/gadgets/moeskin-styles/MediaWiki:Gadget-moeskin-styles.css
+++ b/src/gadgets/moeskin-styles/MediaWiki:Gadget-moeskin-styles.css
@@ -134,10 +134,6 @@ aside#moe-global-siderail #moe-custom-sidenav-block h2 {
     html > body.skin-moeskin .navbox-group + .navbox-list > .navbox-subgroup {
         border-left: 0.75em solid transparent;
     }
-
-    html > body.skin-moeskin .navbox td[rowspan] {
-        display: none;
-    }
 }
 
 :is(.image-box, .image-clip, .fit-image) img.lazyload[data-lazy-state="pending"] {


### PR DESCRIPTION
不记得了就先删了吧，MSP 最近几天试下来也没发现问题


Close #555