### PR TITLE
feat: 新审核系统上线

### DIFF
--- a/src/gadgets/ModerationStatus/definition.yaml
+++ b/src/gadgets/ModerationStatus/definition.yaml
@@ -17,7 +17,7 @@ type: general
 package: false
 
 rights:
-  - edit
+  - disabled
 
 peers: []
 

--- a/src/gadgets/UserMessages/MediaWiki:Gadget-UserMessages.js
+++ b/src/gadgets/UserMessages/MediaWiki:Gadget-UserMessages.js
@@ -855,7 +855,7 @@
         ["UserMessages/EditWar2", "EditWar", "提醒即将构成编辑战（1=页面名）", umsg.umFlagP2, "编辑战提醒"],
         ["UserMessages/EditWar3", "EditWar", "警告编辑战用户（1=页面名，2=选填原因）", umsg.umFlagP2 + umsg.umFlagP3, "编辑战警告"],
         ["UserMessages/FinalWarning", "FinalWarning", "忍耐是有限的（1/2=选填原因，推荐在额外信息填写）", umsg.umFlagP2 + umsg.umFlagP3, "警告：忍耐是有限的"],
-        ["UserMessages/NavSort", "NavSort", "大家族模板排序错误（1-页面名）", umsg.umFlagP2, "关于大家族模板的排序"],
+        ["UserMessages/NavSort", "NavSort", "大家族模板排序错误（1=页面名）", umsg.umFlagP2, "关于大家族模板的排序"],
         ["UserMessages/ReplyNoIndentation", "ReplyNoIndentation", "回复他人发言未缩进（1=页面名，2=被回复人）", umsg.umFlagP2 + umsg.umFlagP3, "关于您在讨论区的发言"],
         ["UserMessages/OverSpeedEdit", "OverSpeedEdit", "超速编辑", umsg.umFlagUM, "关于您近期的编辑"],
     ];

--- a/src/gadgets/moveToUserSubpage/MediaWiki:Gadget-moveToUserSubpage.js
+++ b/src/gadgets/moveToUserSubpage/MediaWiki:Gadget-moveToUserSubpage.js
@@ -216,7 +216,7 @@ $(() => {
                         to: page,
                         movetalk: moveTalk,
                         movesubpages: true,
-                        reason: `${reason} //noredirect`,
+                        reason,
                         noredirect: true,
                         watchlist: watchAfter,
                         tags: "Automation tool",

--- a/src/groups/zh/sysop/MediaWiki:Group-sysop.css
+++ b/src/groups/zh/sysop/MediaWiki:Group-sysop.css
@@ -84,6 +84,6 @@ body[class*="page-萌娘百科_talk_讨论版_"] .userlink .userlink-menu {
     display: none;
 }
 
-li.mw-moderation-line:not(.mw-moderation-approved) input[type='radio'] {
+li.mw-moderation-line:not(.mw-moderation-approved) input[type="radio"] {
     visibility: unset;
 }

--- a/src/groups/zh/sysop/MediaWiki:Group-sysop.css
+++ b/src/groups/zh/sysop/MediaWiki:Group-sysop.css
@@ -84,6 +84,6 @@ body[class*="page-萌娘百科_talk_讨论版_"] .userlink .userlink-menu {
     display: none;
 }
 
-#pagehistory [data-mw-rev-approved="false"] input[type="radio"] {
+li.mw-moderation-line:not(.mw-moderation-approved) input[type='radio'] {
     visibility: unset;
 }


### PR DESCRIPTION
@AnnAngela 需要改一下批量传图工具，传图会返回`moderation-image-queued`，需要视为上传成功

## Summary by Sourcery

启动一个新的审核系统，将"moderation-image-queued"视为成功上传，并增强用户消息模板以提高清晰度。此外，禁用审核状态配置中的编辑权限。

新功能：
- 引入一个新的审核系统，通过将"moderation-image-queued"视为成功上传来处理图像上传。

增强：
- 更新审核状态配置，禁用编辑权限。
- 在 MediaWiki 小工具中优化用户消息模板，提高清晰度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Launch a new moderation system that treats 'moderation-image-queued' as a successful upload and enhance user message templates for improved clarity. Additionally, disable edit rights in the moderation status configuration.

New Features:
- Introduce a new moderation system that handles image uploads by treating 'moderation-image-queued' as a successful upload.

Enhancements:
- Update the moderation status configuration by disabling edit rights.
- Refine user message templates for better clarity in the MediaWiki gadget.

</details>