### PR TITLE
Potential fix for code scanning alert no. 71: Bad HTML filtering regexp

### DIFF
--- a/src/gadgets/code-prettify/Gadget-code-prettify.js
+++ b/src/gadgets/code-prettify/Gadget-code-prettify.js
@@ -970,7 +970,7 @@ $(() => {
         [PR_KEYWORD, /^(?:url|rgb|!important|@import|@page|@media|@charset|inherit)(?=[^\-\w]|$)/i, null],
         ["lang-css-kw", /^(-?(?:[_a-z]|(?:\\[0-9a-f]+ ?))(?:[_a-z0-9-]|\\(?:\\[0-9a-f]+ ?))*)\s*:/i],
         [PR_COMMENT, /^\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\//],
-        [PR_COMMENT, /^(?:<!--|-->)/],
+        [PR_COMMENT, /^(?:<!--|--!?>)/],
         [PR_LITERAL, /^(?:\d+|\d*\.\d+)(?:%|[a-z]+)?/i],
         [PR_LITERAL, /^#(?:[0-9a-f]{3}){1,2}\b/i],
         [PR_PLAIN, /^-?(?:[_a-z]|(?:\\[\da-f]+ ?))(?:[_a-z\d-]|\\(?:\\[\da-f]+ ?))*/i],


### PR DESCRIPTION
Potential fix for [https://github.com/MoegirlPediaInterfaceAdmins/MoegirlPediaInterfaceCodes/security/code-scanning/71](https://github.com/MoegirlPediaInterfaceAdmins/MoegirlPediaInterfaceCodes/security/code-scanning/71)

To fix the problem, we need to update the regular expression to correctly match all valid HTML comment end tags, including `-->` and `--!>`. This can be achieved by modifying the regular expression to account for the additional `!` character that can appear before the closing `>`. 

The best way to fix this without changing existing functionality is to update the regular expression on line 973 to include the `--!>` pattern. This ensures that all valid HTML comment end tags are correctly parsed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

更新用于解析 HTML 注释的正则表达式，使其包含序列 `--!>`。

Bug 修复：
- 修复以 "--!>" 结尾的 HTML 注释的解析。
- 解决关于错误的 HTML 过滤正则表达式的代码扫描警报 no. 71，通过更新正则表达式以正确匹配所有有效的 HTML 注释结束标记，包括 `-->` 和 `--!>`。

<details>
<summary>Original summary in English</summary>

好的，这是翻译成中文的 pull request 总结：

## Sourcery 提供的总结

更新用于解析 HTML 注释的正则表达式，使其包含序列 `--!>`。

Bug 修复：
- 修复了以 "--!>" 结尾的 HTML 注释的解析问题。
- 通过更新正则表达式以正确匹配所有有效的 HTML 注释结束标记（包括 `-->` 和 `--!>`），解决了关于不良 HTML 过滤正则表达式的代码扫描警报 no. 71。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the regular expression for parsing HTML comments to include the sequence `--!>`.

Bug Fixes:
- Fix parsing of HTML comments ending with "--!>".
- Resolve code scanning alert no. 71 regarding bad HTML filtering regexp by updating the regular expression to correctly match all valid HTML comment end tags, including `-->` and `--!>`

</details>

</details>