### PR TITLE
chore: 节过完了

### DIFF
--- a/src/gadgets/april-fool-2025/definition.yaml
+++ b/src/gadgets/april-fool-2025/definition.yaml
@@ -2,7 +2,7 @@ ResourceLoader: true
 
 hidden: true
 
-default: true
+default: false
 
 supportsUrlLoad: false
 


### PR DESCRIPTION
好的，这是将 pull request 摘要翻译成中文的结果：

## Sourcery 总结

杂务：
- 更新配置，将 2025 年愚人节小工具的默认状态设置为 false

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Update the configuration to set the default state of the April Fool's 2025 gadget to false

</details>