### PR TITLE
feat: setupHeimuClickListener

### DIFF
--- a/src/global/zh/Moeskin.js
+++ b/src/global/zh/Moeskin.js
@@ -235,9 +235,8 @@
         document.querySelector("#mw-content-text")?.addEventListener("click", (e) => {
             /** @type {HTMLElement} */
             const target = e.target;
-            const currentHeimu = target.closest(".heimu");
-            const isClickedAnchor = !!target.closest("a");
-            if (currentHeimu && isClickedAnchor) {
+            const currentHeimu = target.closest(".heimu, .colormu, .heimu-like");
+            if (currentHeimu) {
                 // 这个元素是黑幕
                 // 但不是上次点击的黑幕，所以阻止默认行为
                 if (lastClickedHeimu !== currentHeimu) {

--- a/src/global/zh/Moeskin.js
+++ b/src/global/zh/Moeskin.js
@@ -5,6 +5,8 @@
  * 版权协定：知识共享 署名-非商业性使用-相同方式共享 3.0
  */
 (async () => {
+    const IS_MOEPAD_APP = location.hostname === "mobile.moegirl.org.cn";
+
     /**
      * fixWikiLove
      * @FIXME WikiLove
@@ -26,7 +28,7 @@
      * fix a few image issues by extending mw.Title.newFromImg
      * examples including gallery-slideshow and MultiMediaViewer
      */
-    async function fixImage() {
+    const fixImage = async () => {
         await mw.loader.using("mediawiki.Title");
         mw.Title.newFromImg = (img) => {
             let matches, i, regex;
@@ -74,7 +76,7 @@
             await mw.loader.using("mmv.bootstrap.autostart");
             $.proxy(mw.mmv.bootstrap, "processThumbs")(mw.util.$content);
         }
-    }
+    };
 
     /* polyfill */
     /**
@@ -262,7 +264,8 @@
         }).append(noteTAbutton);
         $("#p-languages-group").append(noteTAicon);
     };
-    /* 等待 document 加载完毕 */
+
+    // -------- main --------
     await $.ready;
     /* fixWikiLove */
     fixWikiLove();
@@ -270,14 +273,13 @@
     fixImage();
     /* PageTools */
     applyPageTools();
-    if (Reflect.has(document, "ontouchstart") && !location.host.startsWith("mobile")) {
-        /* linkConfirm */
-        externalLinkConfirm();
-        /* heimuClick */
+    /** 针对触摸屏设备的额外优化 */
+    if (navigator.maxTouchPoints > 0) {
+        !IS_MOEPAD_APP && externalLinkConfirm(); // App 有自己的链接处理逻辑
         setupHeimuClickListener();
     }
     /* noteTAIcon */
-    if ($(".noteTA")[0]) {
+    if ($(".noteTA").length > 0) {
         noteTAIcon();
     }
 })();


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

引入一个新的点击监听器，以防止意外激活 `.heimu` 元素内的链接。现在需要用户点击两次才能访问链接。同时，重构了之前的 jQuery 处理程序，改用原生事件监听器。

新特性：
- 添加 `setupHeimuClickListener` 来管理 `.heimu` 元素的点击行为，需要第二次点击才能激活其中的链接。

增强功能：
- 将基于 jQuery 的 `.heimu` 链接点击处理程序替换为原生事件监听器，以改进点击管理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a new click listener to prevent accidental activation of links within .heimu elements, requiring users to click twice to follow links, and refactor the previous jQuery handler to use a native event listener.

New Features:
- Add setupHeimuClickListener to manage click behavior on .heimu elements, requiring a second click to activate links within them.

Enhancements:
- Replace jQuery-based .heimu link click handler with a native event listener for improved click management.

</details>