### PR TITLE
docs: 多了个冒号

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <details><summary>仓库架构详情</summary>
 
 - [`.github`](.github) 文件夹用以保存 GitHub Dependabot 和 GitHub Actions 所需配置文件，其中：
-  - [`.github/workflows/postCommit.yaml`](.github/workflows/postCommit.yaml) 用以保存自动化流程，包含自动配置 Conventional Commits（约定式提交）所需 scope（作用域）信息、自动导入来自 npm 和指定页面的代码、自动补全小工具列表；：
+  - [`.github/workflows/postCommit.yaml`](.github/workflows/postCommit.yaml) 用以保存自动化流程，包含自动配置 Conventional Commits（约定式提交）所需 scope（作用域）信息、自动导入来自 npm 和指定页面的代码、自动补全小工具列表；
   - [`.github/workflows/generatePolyfill.yaml`](.github/workflows/generatePolyfill.yaml) 用以自动生成 polyfill 文件；
   - [`.github/workflows/auto_assign.yaml`](.github/workflows/auto_assign.yaml) 用以自动对 pull request 和 issue 添加 assignees 和 reviewers（若有）。
 - [`.vscode/settings.json`](.vscode/settings.json) 用来保存 Conventional Commits（约定式提交）所需 scope（作用域）信息；


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

文档：
- 移除 README.md 文件中 .github/workflows/postCommit.yaml 描述末尾多余的冒号。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Remove redundant colon at the end of the .github/workflows/postCommit.yaml description in README.md

</details>