### PR TITLE
feat(Gadget-wikieditor-highlight): 更新

### DIFF
--- a/src/gadgets/wikieditor-highlight/Gadget-wikieditor-highlight.js
+++ b/src/gadgets/wikieditor-highlight/Gadget-wikieditor-highlight.js
@@ -9,7 +9,7 @@
     let cm;
     let state = localObjectStorage.getItem("wikieditor-codemirror", true);
     const $textarea = $("#wpTextbox1");
-    if (mw.config.get("wgPageContentModel") !== "wikitext" && (mw.user.options.get("usecodeeditor") || $textarea.data('wikiEditorContext')?.codeEditorActive)) {
+    if (mw.config.get("wgPageContentModel") !== "wikitext" && (mw.user.options.get("usecodeeditor") || $textarea.data("wikiEditorContext")?.codeEditorActive)) {
         state = false;
     }
     const isAdvanced = ["loading", "loaded", "executing", "ready"].includes(mw.loader.getState("ext.wikiEditor"));

--- a/src/gadgets/wikieditor-highlight/Gadget-wikieditor-highlight.js
+++ b/src/gadgets/wikieditor-highlight/Gadget-wikieditor-highlight.js
@@ -23,17 +23,9 @@
     const btnHighlight = new OO.ui.ButtonWidget({
         classes: ["tool"], icon: "highlight", framed: false, title: "代码高亮开关",
     }).on("click", () => {
-        (async () => {
-            if (cm) {
-                cm.toggle();
-                $(".group-codeeditor-main").toggle();
-            } else {
-                await init();
-            }
-            btnHighlight.$element.remove();
-            state = !state;
-            localObjectStorage.setItem("wikieditor-codemirror", state);
-        })();
+        init();
+        btnHighlight.$element.remove();
+        localObjectStorage.setItem("wikieditor-codemirror", true);
     });
     $textarea.on("wikiEditor-toolbar-doneInitialSections", () => {
         btnHighlight.$element.appendTo("#wikiEditor-section-main > .group-insert");

--- a/src/gadgets/wikieditor-highlight/Gadget-wikieditor-highlight.js
+++ b/src/gadgets/wikieditor-highlight/Gadget-wikieditor-highlight.js
@@ -8,10 +8,10 @@
     const localObjectStorage = new LocalObjectStorage("wikieditor-highlight");
     let cm;
     let state = localObjectStorage.getItem("wikieditor-codemirror", true);
-    if (mw.config.get("wgPageContentModel") !== "wikitext" && mw.user.options.get("usecodeeditor")) {
+    const $textarea = $("#wpTextbox1");
+    if (mw.config.get("wgPageContentModel") !== "wikitext" && (mw.user.options.get("usecodeeditor") || $textarea.data('wikiEditorContext')?.codeEditorActive)) {
         state = false;
     }
-    const $textarea = $("#wpTextbox1");
     const isAdvanced = ["loading", "loaded", "executing", "ready"].includes(mw.loader.getState("ext.wikiEditor"));
     const init = async () => {
         if (!window.CodeMirror6) {

--- a/src/gadgets/wikieditor-highlight/Gadget-wikieditor-highlight.js
+++ b/src/gadgets/wikieditor-highlight/Gadget-wikieditor-highlight.js
@@ -20,11 +20,6 @@
         init();
         return;
     }
-    const btnSettings = new OO.ui.ButtonWidget({
-        classes: ["tool"], icon: "settings", framed: false, title: "代码高亮设置",
-    }).on("click", () => {
-        $("#cm-settings").trigger("click");
-    });
     const btnHighlight = new OO.ui.ButtonWidget({
         classes: ["tool"], icon: "highlight", framed: false, title: "代码高亮开关",
     }).on("click", () => {
@@ -32,12 +27,10 @@
             if (cm) {
                 cm.toggle();
                 $(".group-codeeditor-main").toggle();
-                btnSettings.$element.toggle();
             } else {
                 await init();
-                btnHighlight.$element.after(btnSettings.$element);
             }
-            btnHighlight.$element.toggleClass("tool-active");
+            btnHighlight.$element.remove();
             state = !state;
             localObjectStorage.setItem("wikieditor-codemirror", state);
         })();
@@ -55,7 +48,6 @@
     if (state) {
         await mw.loader.using(["ext.wikiEditor", "oojs-ui.styles.icons-interactions"]);
         await init();
-        btnHighlight.$element.addClass("tool-active");
-        btnHighlight.$element.after(btnSettings.$element);
+        btnHighlight.$element.remove();
     }
 })();

--- a/src/gadgets/wikiplus-highlight/Gadget-wikiplus-highlight.js
+++ b/src/gadgets/wikiplus-highlight/Gadget-wikiplus-highlight.js
@@ -1,4 +1,6 @@
 "use strict";
 (async () => {
-    await libCachedCode.injectCachedCode("https://testingcf.jsdelivr.net/npm/wikiplus-highlight@latest", "script");
+    if (mw.config.get("wgIsArticle") && mw.config.get("wgAction") === "view") {
+        await libCachedCode.injectCachedCode("https://testingcf.jsdelivr.net/npm/wikiplus-highlight@latest", "script");
+    }
 })();


### PR DESCRIPTION
1. 移除WikiEditor工具条上重复的CodeMirror6开关和设置按钮，并处理JS/CSS/JSON/Lua页面上与CodeEditor的冲突。
2. 只在Wikiplus有可能运行的条件下加载Wikiplus-highlight。

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

移除重复的 CodeMirror 工具栏按钮，简化切换行为，并防止在非维基文本页面上使用默认 CodeEditor 时激活 CodeMirror。

Bug 修复：
- 当原生 CodeEditor 处于活动状态时，禁用在非维基文本页面上初始化 CodeMirror，以防止冲突。

增强功能：
- 从 WikiEditor 工具栏中移除冗余的 CodeMirror6 切换和设置按钮。
- 通过合并到单个高亮按钮来简化工具栏切换逻辑。
- 通过工具栏切换事件将 CodeMirror 切换状态持久化到本地存储。
- 结合状态和高级编辑器检查来简化 CodeMirror 初始化。

<details>
<summary>Original summary in English</summary>

好的，这是翻译成简体中文的 pull request 总结：

## Sourcery 总结

从 WikiEditor 工具栏中移除重复的 CodeMirror 控件，将切换行为简化为一个高亮按钮，持久化切换状态，并防止与非维基文本页面上的原生代码编辑器发生冲突。

Bug 修复：
- 阻止在非维基文本页面上初始化 CodeMirror，以避免与激活的原生代码编辑器冲突。

增强功能：
- 从 WikiEditor 工具栏中移除冗余的 CodeMirror6 切换和设置按钮。
- 将 CodeMirror 切换合并为一个高亮按钮，并简化其初始化逻辑。
- 通过工具栏切换在本地存储中持久化 CodeMirror 启用状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove duplicate CodeMirror controls from the WikiEditor toolbar, simplify the toggle behavior into a single highlight button, persist toggle state, and prevent conflicts with the native code editor on non-wikitext pages.

Bug Fixes:
- Prevent CodeMirror initialization on non-wikitext pages when the native CodeEditor is active to avoid conflicts.

Enhancements:
- Remove redundant CodeMirror6 toggle and settings buttons from the WikiEditor toolbar.
- Consolidate CodeMirror toggle into a single highlight button and streamline its initialization logic.
- Persist CodeMirror enabled state in local storage via toolbar toggles.

</details>

</details>