### PR TITLE
fix:修复“扩充侧边栏”样式问题

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -25,3 +25,4 @@ Func <Funcer@outlook.com>
 云霞 <37736595+Kumokasumi@users.noreply.github.com>
 Dreammu <84692291+dreammu@users.noreply.github.com>
 SaoMikoto <Saoutax@outlook.com>
+LJL <ljlorljl@163.com>

--- a/src/gadgets/mwPanel/Gadget-mwPanel.js
+++ b/src/gadgets/mwPanel/Gadget-mwPanel.js
@@ -4,13 +4,13 @@ $(() => {
     const wgPageName = mw.config.get("wgRelevantPageName");
     const items = {
         "#t-upload": {
-            "t-expandtemplates": `<li id="t-expandtemplates"><a href="/Special:展开模板?wpRemoveComments=1&wpInput={{${wgPageName}}}">${wgULS("展开模板", "展開模板")}</a></li>`,
-            "t-prefixindex": `<li id="t-prefixindex"><a href="/Special:前缀索引?prefix=${wgPageName}">${wgULS("前缀页面", "按詞頭查詢頁面")}</a></li>`,
-            "t-pagelog": `<li id="t-pagelog"><a href="/Special:日志?page=${wgPageName}">${wgULS("页面日志", "頁面日誌")}</a></li>`,
-            "t-replacetext": `<li id="t-replacetext" class="sysop-show"><a href="/Special:替换文本">${wgULS("替换文本", "取代文字")}</a></li>`,
+            "t-expandtemplates": `<li id="t-expandtemplates" class="mw-list-item"><a href="/Special:展开模板?wpRemoveComments=1&wpInput={{${wgPageName}}}">${wgULS("展开模板", "展開模板")}</a></li>`,
+            "t-prefixindex": `<li id="t-prefixindex" class="mw-list-item"><a href="/Special:前缀索引?prefix=${wgPageName}">${wgULS("前缀页面", "按詞頭查詢頁面")}</a></li>`,
+            "t-pagelog": `<li id="t-pagelog" class="mw-list-item"><a href="/Special:日志?page=${wgPageName}">${wgULS("页面日志", "頁面日誌")}</a></li>`,
+            "t-replacetext": `<li id="t-replacetext" class="sysop-show mw-list-item"><a href="/Special:替换文本">${wgULS("替换文本", "取代文字")}</a></li>`,
         },
         "#n-recentchanges": {
-            "n-log": `<li id="n-log"><a href="/Special:日志" title="所有日志">${wgULS("所有日志", "所有日誌")}</a></li>`,
+            "n-log": `<li id="n-log" class="mw-list-item"><a href="/Special:日志" title="所有日志">${wgULS("所有日志", "所有日誌")}</a></li>`,
         },
     };
     for (const t in items) {


### PR DESCRIPTION
为vector皮肤工具“扩充侧边栏”（mwpanel.js）中显示的文本内容增加vector2022中的菜单类"mw-list-item"，以实现菜单文本之间间隔与vector2022自有的菜单文本间隔达到统一。

## Sourcery 总结

错误修复：
- 为扩展模板、前缀索引、页面日志、替换文本和通用日志条目的自定义侧边栏列表项添加“mw-list-item”类

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add "mw-list-item" class to custom sidebar list items for expand templates, prefix index, page log, replace text, and general log entries

</details>