### PR TITLE
fix(Gadget/InPageEdit-v2): 修复vector2022顶栏快速编辑按钮

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -26,3 +26,4 @@ Func <Funcer@outlook.com>
 Dreammu <84692291+dreammu@users.noreply.github.com>
 SaoMikoto <Saoutax@outlook.com>
 LJL <ljlorljl@163.com>
+SaoMikoto <Saoutax@gmail.com>

--- a/src/gadgets/InPageEdit-v2/Gadget-InPageEdit-v2.js
+++ b/src/gadgets/InPageEdit-v2/Gadget-InPageEdit-v2.js
@@ -11,19 +11,17 @@ mw.hook("InPageEdit").add((ctx) => {
             $("#ca-edit").after(
                 $("<li>", {
                     id: "ca-quick-edit",
-                    "class": "collapsible",
+                    class: "vector-tab-noicon mw-list-item"
                 }).append(
-                    $("<span>").append(
-                        $("<a>", {
-                            href: "javascript:void(0)",
-                            text: typeof Wikiplus !== "undefined" ? `${_msg("quick-edit")}(IPE)` : _msg("quick-edit"),
-                        }).on("click", () => {
-                            InPageEdit.quickEdit({
-                                page: wgPageName,
-                                revision: wgRevisionId || undefined,
-                            });
-                        }),
-                    ),
+                    $("<a>", {
+                        href: "javascript:void(0)",
+                        text: typeof Wikiplus !== "undefined" ? `${_msg("quick-edit")}(IPE)` : _msg("quick-edit"),
+                    }).on("click", () => {
+                        InPageEdit.quickEdit({
+                            page: wgPageName,
+                            revision: wgRevisionId || undefined,
+                        });
+                    }),
                 ),
             );
             break;

--- a/src/gadgets/editCount/Gadget-editCount.js
+++ b/src/gadgets/editCount/Gadget-editCount.js
@@ -1,4 +1,7 @@
 "use strict";
 $(() => {
-    $("#pt-mycontris").append(`(${mw.config.get("wgUserEditCount")})`);
+    mw.loader.addStyleTag(`#pt-mycontris > a::after {
+        content: "(${mw.config.get("wgUserEditCount")})";
+        margin-left: .1em;
+    }`);
 });

--- a/src/global/zh/GHIAHistory.json
+++ b/src/global/zh/GHIAHistory.json
@@ -2324,6 +2324,11 @@
     ],
     "U:SaoMikoto": [
         {
+            "commit": "c10d9d5c64420a528e170fb43de02aaa7dd70ac4",
+            "datetime": "2025-08-10T02:45:19.000Z",
+            "changedFiles": 1
+        },
+        {
             "commit": "ca3187e55a5690aeccf4cecef259a34e3bac8176",
             "datetime": "2025-08-09T14:59:53.000Z",
             "changedFiles": 1


### PR DESCRIPTION
## Sourcery 总结

修复 InPageEdit-v2 中 Vector 2022 顶部栏快速编辑按钮，方法是更新其列表项类并简化 HTML 结构

错误修复：
- 更改快速编辑标签的列表项类从 "collapsible" 到 "vector-tab-noicon mw-list-item"
- 移除快速编辑链接周围不必要的 span 包装器以实现正确的样式

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the Vector 2022 top-bar quick-edit button in InPageEdit-v2 by updating its list item class and simplifying the HTML structure

Bug Fixes:
- Change the quick-edit tab’s list item class from "collapsible" to "vector-tab-noicon mw-list-item"
- Remove the unnecessary span wrapper around the quick-edit link for proper styling

</details>