### PR TITLE
fix(Gadget/InPageEdit-v2): 修复vector2022顶栏的快速编辑

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -26,3 +26,4 @@ Func <Funcer@outlook.com>
 Dreammu <84692291+dreammu@users.noreply.github.com>
 SaoMikoto <Saoutax@outlook.com>
 LJL <ljlorljl@163.com>
+SaoMikoto <Saoutax@gmail.com>

--- a/src/gadgets/InPageEdit-v2/Gadget-InPageEdit-v2.js
+++ b/src/gadgets/InPageEdit-v2/Gadget-InPageEdit-v2.js
@@ -11,7 +11,7 @@ mw.hook("InPageEdit").add((ctx) => {
             $("#ca-edit").after(
                 $("<li>", {
                     id: "ca-quick-edit",
-                    class: "vector-tab-noicon mw-list-item",
+                    "class": "vector-tab-noicon mw-list-item",
                 }).append(
                     $("<a>", {
                         href: "javascript:void(0)",

--- a/src/gadgets/InPageEdit-v2/Gadget-InPageEdit-v2.js
+++ b/src/gadgets/InPageEdit-v2/Gadget-InPageEdit-v2.js
@@ -11,19 +11,17 @@ mw.hook("InPageEdit").add((ctx) => {
             $("#ca-edit").after(
                 $("<li>", {
                     id: "ca-quick-edit",
-                    "class": "collapsible",
+                    class: "vector-tab-noicon mw-list-item"
                 }).append(
-                    $("<span>").append(
-                        $("<a>", {
-                            href: "javascript:void(0)",
-                            text: typeof Wikiplus !== "undefined" ? `${_msg("quick-edit")}(IPE)` : _msg("quick-edit"),
-                        }).on("click", () => {
-                            InPageEdit.quickEdit({
-                                page: wgPageName,
-                                revision: wgRevisionId || undefined,
-                            });
-                        }),
-                    ),
+                    $("<a>", {
+                        href: "javascript:void(0)",
+                        text: typeof Wikiplus !== "undefined" ? `${_msg("quick-edit")}(IPE)` : _msg("quick-edit"),
+                    }).on("click", () => {
+                        InPageEdit.quickEdit({
+                            page: wgPageName,
+                            revision: wgRevisionId || undefined,
+                        });
+                    }),
                 ),
             );
             break;

--- a/src/gadgets/InPageEdit-v2/Gadget-InPageEdit-v2.js
+++ b/src/gadgets/InPageEdit-v2/Gadget-InPageEdit-v2.js
@@ -11,7 +11,7 @@ mw.hook("InPageEdit").add((ctx) => {
             $("#ca-edit").after(
                 $("<li>", {
                     id: "ca-quick-edit",
-                    class: "vector-tab-noicon mw-list-item"
+                    class: "vector-tab-noicon mw-list-item",
                 }).append(
                     $("<a>", {
                         href: "javascript:void(0)",


### PR DESCRIPTION
## Sourcery 总结

修复 InPageEdit-v2 快速编辑标签页的样式和结构，以兼容 Vector 2022 顶部栏

错误修复：
- 更新快速编辑标签页的标记和类，使其使用 `vector-tab-noicon mw-list-item` 而不是 `collapsible`
- 删除快速编辑链接周围不必要的 `<span>` 包装器，以在 Vector 2022 顶部栏中实现正确对齐

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the InPageEdit-v2 quick-edit tab styling and structure for compatibility with the Vector 2022 top bar

Bug Fixes:
- Update the quick-edit tab markup and classes to use vector-tab-noicon mw-list-item instead of collapsible
- Remove unnecessary span wrapper around the quick-edit link for proper alignment in Vector 2022 top bar

</details>