### PR TITLE
fix(Gadget/editCount): 优化样式

### DIFF
--- a/src/gadgets/editCount/Gadget-editCount.js
+++ b/src/gadgets/editCount/Gadget-editCount.js
@@ -1,4 +1,7 @@
 "use strict";
 $(() => {
-    $("#pt-mycontris").append(`(${mw.config.get("wgUserEditCount")})`);
+    mw.loader.addStyleTag(`#pt-mycontris > a::after {
+        content: "(${mw.config.get("wgUserEditCount")})";
+        margin-left: .1em;
+    }`);
 });


### PR DESCRIPTION
## Sourcery 总结

通过 CSS 伪元素渲染用户编辑计数，而非直接操作 DOM

改进：
- 使用 `mw.loader.addStyleTag` 注入 CSS，将编辑计数作为内容添加到贡献链接的 `::after` 伪元素中
- 移除用于插入编辑计数的 `jQuery append` 调用，并调整边距以获得视觉间距

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Render the user edit count via a CSS pseudo-element instead of direct DOM manipulation

Enhancements:
- Use mw.loader.addStyleTag to inject CSS that adds the edit count as content in the contributions link’s ::after pseudo-element
- Remove the jQuery append call for inserting the edit count and adjust margin for visual spacing

</details>