### PR TITLE
fix(Gadget/vector-2022-styles): 个人菜单间距修复

### DIFF
--- a/src/gadgets/vector-2022-styles/Gadget-vector-2022-styles.css
+++ b/src/gadgets/vector-2022-styles/Gadget-vector-2022-styles.css
@@ -27,3 +27,7 @@
     left: -999vw
   }
 }
+
+#p-personal li {
+    margin-top: 0.2em;
+}


### PR DESCRIPTION
## Sourcery 总结

错误修复:
- 为 #p-personal 菜单中的列表项添加 0.2em 上边距，以修正间距

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add 0.2em top margin to list items in the #p-personal menu to correct spacing

</details>