### PR TITLE
fix(Gadget/patrolCount): 适配vector2022

### DIFF
--- a/src/gadgets/patrolCount/Gadget-patrolCount.js
+++ b/src/gadgets/patrolCount/Gadget-patrolCount.js
@@ -95,7 +95,7 @@ $(() => {
                     "font-weight": "bold",
                     "margin-bottom": "10px",
                 }).append($("<a></a>", {
-                    text: "more...",
+                    text: "更多...",
                     href: "#patrollListShowAll",
                     title: "显示所有未巡查页面",
                 }));

--- a/src/gadgets/patrolCount/Gadget-patrolCount.js
+++ b/src/gadgets/patrolCount/Gadget-patrolCount.js
@@ -95,9 +95,9 @@ $(() => {
                     "font-weight": "bold",
                     "margin-bottom": "10px",
                 }).append($("<a></a>", {
-                    text: "更多...",
+                    text: "更多……",
                     href: "#patrollListShowAll",
-                    title: "显示所有未巡查页面",
+                    title: wgULS("显示所有未巡查页面", "顯示所有未巡查的頁面"),
                 }));
                 $list.after($showAll);
             } else {
@@ -354,7 +354,7 @@ $(() => {
         const addlink = (page) => {
             let $patrollinks = $("<a></a>", {
                 href: `index.php?title=${encodeURIComponent(page.title)}&rcid=${encodeURIComponent(page.rcid)}`,
-                text: "标记此页面为已巡查",
+                text: wgULS("标记此页面为已巡查", "標記此頁面為已巡查"),
             });
             const $divPatrolllink = $("<div></div>", {
                 "class": "patrollink",

--- a/src/gadgets/patrolCount/Gadget-patrolCount.js
+++ b/src/gadgets/patrolCount/Gadget-patrolCount.js
@@ -97,7 +97,7 @@ $(() => {
                 }).append($("<a></a>", {
                     text: "more...",
                     href: "#patrollListShowAll",
-                    title: "Show all unpatrolled articles",
+                    title: "显示所有未巡查页面",
                 }));
                 $list.after($showAll);
             } else {
@@ -448,7 +448,7 @@ $(() => {
         title: wgULS("最新页面", "最新頁面"),
         text: wgULS("最新页面", "最新頁面"),
     });
-    $("body #p-personal ul li#pt-watchlist").after($("<li></li>", {
+    $("#pt-watchlist-2").after($("<li></li>", {
         id: "pt-patroll",
     }).append(ptPatrollLink).append($("<span></span>", {
         id: "not-patrolled-count",


### PR DESCRIPTION
## Sourcery 摘要

通过更新 UI 选择器和本地化，使 patrolCount 小工具适配 Vector 2022 皮肤

增强:
- 将“更多…”链接标题更改为中文，以与本地化保持一致
- 更新监视列表菜单选择器以匹配 Vector 2022，并正确插入巡逻链接

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adapt the patrolCount gadget for the Vector 2022 skin by updating UI selectors and localization

Enhancements:
- Change the “more…” link title to Chinese for consistency with localization
- Update the watchlist menu selector to match Vector 2022 and correctly insert the patrol link

</details>