### PR TITLE
fix:修复moveToUserSubpage小工具报错问题

### DIFF
--- a/src/gadgets/moveToUserSubpage/Gadget-moveToUserSubpage.js
+++ b/src/gadgets/moveToUserSubpage/Gadget-moveToUserSubpage.js
@@ -10,8 +10,8 @@ $(() => {
         if (pageid === 0
             || $(".will2Be2Deleted")[0]
             || !mw.config.get("wgUserGroups").includes("patroller") && !mw.config.get("wgUserGroups").includes("sysop")
-            || mw.config.get("wgRestrictionMove")?.includes("sysop") && !mw.config.get("wgUserRights").includes("editprotected")
-            || mw.config.get("wgRestrictionMove")?.includes("techedit") && !mw.config.get("wgUserRights").includes("techedit")
+            || mw.config.get("wgRestrictionMove")?.includes("sysop") && !mw.config.get("wgUserGroups").includes("sysop")
+            || mw.config.get("wgRestrictionMove")?.includes("techedit") && !mw.config.get("wgUserGroups").includes("techeditor")
             || !mw.config.get("wgIsProbablyEditable")
         ) {
             return;

--- a/src/gadgets/moveToUserSubpage/Gadget-moveToUserSubpage.js
+++ b/src/gadgets/moveToUserSubpage/Gadget-moveToUserSubpage.js
@@ -10,8 +10,8 @@ $(() => {
         if (pageid === 0
             || $(".will2Be2Deleted")[0]
             || !mw.config.get("wgUserGroups").includes("patroller") && !mw.config.get("wgUserGroups").includes("sysop")
-            || mw.config.get("wgRestrictionMove")?.includes("sysop") && !mw.config.get("wgUserGroups").includes("sysop")
-            || mw.config.get("wgRestrictionMove")?.includes("techedit") && !mw.config.get("wgUserGroups").includes("techeditor")
+            || mw.config.get("wgRestrictionMove")?.includes("sysop") && !mw.config.get("wgUserGroups")?.includes("sysop")
+            || mw.config.get("wgRestrictionMove")?.includes("techedit") && !mw.config.get("wgUserGroups")?.includes("techeditor")
             || !mw.config.get("wgIsProbablyEditable")
         ) {
             return;


### PR DESCRIPTION
#692 
由于鬼影233的失误导致的问题，回滚之前的更改。

## 由 Sourcery 提供的总结

回滚对 `moveToUserSubpage` 小工具的有问题的更改，并恢复用于移动页面的正确的基于组的权限检查

错误修复:
- 恢复使用 `wgUserGroups` 而非 `wgUserRights` 来进行管理员（`sysop`）移动限制
- 更正 `techedit` 组检查，以在 `wgUserGroups` 中使用 "techeditor"

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revert faulty changes to the moveToUserSubpage gadget and restore correct group-based permission checks for moving pages

Bug Fixes:
- Restore the use of wgUserGroups instead of wgUserRights for sysop move restrictions
- Correct the techedit group check to use "techeditor" in wgUserGroups

</details>