### PR TITLE
fix(Gadget/moveToUserSubpage): 允许sysop于techedit启用

### DIFF
--- a/src/gadgets/moveToUserSubpage/Gadget-moveToUserSubpage.js
+++ b/src/gadgets/moveToUserSubpage/Gadget-moveToUserSubpage.js
@@ -11,6 +11,7 @@ $(() => {
             || $(".will2Be2Deleted")[0]
             || !mw.config.get("wgUserGroups").includes("patroller") && !mw.config.get("wgUserGroups").includes("sysop")
             || mw.config.get("wgRestrictionMove")?.includes("sysop") && !mw.config.get("wgUserGroups")?.includes("sysop")
+            || mw.config.get("wgRestrictionMove")?.includes("techedit") && !mw.config.get("wgUserGroups")?.includes("sysop")
             || mw.config.get("wgRestrictionMove")?.includes("techedit") && !mw.config.get("wgUserGroups")?.includes("techeditor")
             || !mw.config.get("wgIsProbablyEditable")
         ) {

--- a/src/gadgets/moveToUserSubpage/Gadget-moveToUserSubpage.js
+++ b/src/gadgets/moveToUserSubpage/Gadget-moveToUserSubpage.js
@@ -25,7 +25,7 @@ $(() => {
             return;
         }
         for (const restriction of wgRestrictionMove) {
-            if requiredGroups[restriction]?.every((group) => !wgUserGroups.includes(group))) {
+            if (requiredGroups[restriction]?.every((group) => !wgUserGroups.includes(group))) {
                 return;
             }
         }

--- a/src/gadgets/moveToUserSubpage/Gadget-moveToUserSubpage.js
+++ b/src/gadgets/moveToUserSubpage/Gadget-moveToUserSubpage.js
@@ -1,30 +1,38 @@
 // <pre>
 "use strict";
-// await mw.loader.using(["ext.gadget.site-lib", "oojs-ui", "mediawiki.api", "mediawiki.notification", "mediawiki.notify"]);
 $(() => {
     try {
-        const pagens = mw.config.get("wgNamespaceNumber");
-        const pageid = mw.config.get("wgArticleId");
-        const username = mw.config.get("wgUserName");
-        const isModule = pagens === 828;
-        if (pageid === 0
+        const { wgNamespaceNumber, wgArticleId, wgUserName, wgUserGroups, wgRestrictionMove, wgIsProbablyEditable, wgPageName, wgTitle } = mw.config.get([
+            "wgNamespaceNumber",
+            "wgArticleId",
+            "wgUserName",
+            "wgUserGroups",
+            "wgRestrictionMove",
+            "wgIsProbablyEditable",
+            "wgPageName",
+            "wgTitle",
+        ]);
+        const isModule = wgNamespaceNumber === 828;
+        const requiredGroups = {
+            sysop: ["sysop"],
+            techeditor: ["techeditor", "sysop"],
+        };
+        if (wgArticleId === 0
             || $(".will2Be2Deleted")[0]
-            || !mw.config.get("wgUserGroups").includes("patroller") && !mw.config.get("wgUserGroups").includes("sysop")
-            || mw.config.get("wgRestrictionMove")?.includes("sysop") && !mw.config.get("wgUserGroups")?.includes("sysop")
-            || mw.config.get("wgRestrictionMove")?.includes("techedit") && !mw.config.get("wgUserGroups")?.includes("sysop")
-            || mw.config.get("wgRestrictionMove")?.includes("techedit") && !mw.config.get("wgUserGroups")?.includes("techeditor")
-            || !mw.config.get("wgIsProbablyEditable")
+            || !wgUserGroups.includes("patroller") && !wgUserGroups.includes("sysop")
+            || !wgIsProbablyEditable
         ) {
             return;
         }
-
-        // RL is unreliable
-        // await mw.loader.using(["oojs-ui", "mediawiki.api", "mediawiki.notification", "mediawiki.notify"]);
+        for (const restriction of wgRestrictionMove) {
+            if (Array.isArray(requiredGroups[restriction]) && !requiredGroups[restriction].some((group) => wgUserGroups.includes(group))) {
+                return;
+            }
+        }
 
         const $body = $("body");
         $("#mw-notification-area").appendTo($body);
 
-        const pagename = mw.config.get("wgPageName");
         const convTemplate = (str, name, val) => str.replaceAll(`$${name}`, val);
         class MTUSWindow extends OO.ui.ProcessDialog {
             static static = {
@@ -67,7 +75,7 @@ $(() => {
                     value: "提醒：请不要创建低质量页面",
                 });
                 this.notifContentBox = new OO.ui.MultilineTextInputWidget({
-                    value: `您好，您最近创建的“${pagename}”页面由于质量不足，待审核通过后将被移动至${isModule ? "[[Module:Sandbox]]下您的[[$2|用户名页面子页面]]" : "您的[[$2|用户页子页面]]"}下。请您以后避免在页面尚未达到最低质量标准的情况下直接在主名字空间创建。您可以先于[[Special:MyPage/sandbox|您的沙盒]]创建，待质量达到标准后再申请[[Help:移动页面|移动]]回主名字空间。感谢您的配合，祝您编辑愉快！`,
+                    value: `您好，您最近创建的“${wgPageName}”页面由于质量不足，待审核通过后将被移动至${isModule ? "[[Module:Sandbox]]下您的[[$2|用户名页面子页面]]" : "您的[[$2|用户页子页面]]"}下。请您以后避免在页面尚未达到最低质量标准的情况下直接在主名字空间创建。您可以先于[[Special:MyPage/sandbox|您的沙盒]]创建，待完善后再[[Help:移动页面|移动]]回主名字空间。感谢您的配合，祝您编辑愉快！`,
                     autosize: true,
                 });
                 this.noNoticeBox = new OO.ui.CheckboxInputWidget();
@@ -187,11 +195,11 @@ $(() => {
                 if (!this.warnings.multipleContribs) {
                     const contribs = (await api.get({
                         action: "query",
-                        assertuser: username,
+                        assertuser: wgUserName,
                         prop: "contributors",
-                        pageids: pageid,
+                        pageids: wgArticleId,
                         pclimit: 2,
-                    })).query.pages[pageid].contributors;
+                    })).query.pages[wgArticleId].contributors;
                     if (contribs.length > 1) {
                         throw {
                             warning: true,
@@ -204,20 +212,20 @@ $(() => {
                 // 查询创建者用户名
                 const user = (await api.get({
                     action: "query",
-                    assertuser: username,
+                    assertuser: wgUserName,
                     prop: "revisions",
-                    titles: pagename,
+                    titles: wgPageName,
                     rvprop: "user",
                     rvlimit: 1,
                     rvdir: "newer",
-                })).query.pages[pageid].revisions[0].user;
-                const page = isModule ? `Module:Sandbox/${user}/${mw.config.get("wgTitle")}` : `User:${user}/${pagename}`;
+                })).query.pages[wgArticleId].revisions[0].user;
+                const page = isModule ? `Module:Sandbox/${user}/${wgTitle}` : `User:${user}/${wgPageName}`;
 
                 if (!noNotice) {
                     // 留言
                     const notifRes = await api.postWithToken("csrf", {
                         action: "edit",
-                        assertuser: username,
+                        assertuser: wgUserName,
                         format: "json",
                         title: `User talk:${user}`,
                         section: "new",
@@ -235,8 +243,8 @@ $(() => {
                 try {
                     const moveRes = await api.postWithToken("csrf", {
                         action: "move",
-                        assertuser: username,
-                        from: pagename,
+                        assertuser: wgUserName,
+                        from: wgPageName,
                         to: page,
                         movetalk: moveTalk,
                         movesubpages: true,

--- a/src/gadgets/moveToUserSubpage/Gadget-moveToUserSubpage.js
+++ b/src/gadgets/moveToUserSubpage/Gadget-moveToUserSubpage.js
@@ -25,7 +25,7 @@ $(() => {
             return;
         }
         for (const restriction of wgRestrictionMove) {
-            if (Array.isArray(requiredGroups[restriction]) && !requiredGroups[restriction].some((group) => wgUserGroups.includes(group))) {
+            if requiredGroups[restriction]?.every((group) => !wgUserGroups.includes(group))) {
                 return;
             }
         }


### PR DESCRIPTION
## Sourcery 总结

错误修复：
- 免除管理员（sysop）的技术编辑移动限制，以便他们仍能在仅限技术编辑的页面上激活小工具。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Exempt sysop from techedit move restrictions so they can still activate the gadget on techedit-only pages

</details>