### PR TITLE
fix(Gadget/quickMoveThread): 适配高版本

### DIFF
--- a/src/gadgets/quickMoveThread/Gadget-quickMoveThread.js
+++ b/src/gadgets/quickMoveThread/Gadget-quickMoveThread.js
@@ -236,13 +236,13 @@ $(() => {
         });
         windowManager.addWindows([qmtDialog]);
 
-        $(".mw-parser-output h2").each((_, ele) => {
-            const $ele = $(ele);
+        $(".mw-parser-output .mw-heading h2").each((_, ele) => {
+            const $ele = $(ele).parent();
             if (!$ele.find(".mw-editsection")[0] || $ele.next(".movedToNotice, .movedFromNotice, .saveNotice")[0]) {
                 return;
             }
             const section = +new mw.Uri($ele.find('.mw-editsection a[href*="action=edit"][href*="section="]').attr("href")).query.section;
-            const anchor = $ele.find(".mw-headline").attr("id");
+            const anchor = $(ele).attr("id");
             const button = $("<a>").attr("href", "#").prop("draggable", false).addClass("lr-qmt-link").text(wgULS("移动", "移動")).on("click", (e) => {
                 e.preventDefault();
                 windowManager.openWindow(qmtDialog, { section, anchor });


### PR DESCRIPTION
## Sourcery 总结

更新 quickMoveThread 小工具，通过调整标题和锚点选择器来支持较新软件版本中更新的 DOM 结构。

错误修复：
- 修改标题选择器，以定位 .mw-heading 容器内的 h2 元素。
- 更改锚点 ID 获取方式，以直接使用 h2 元素的 id 属性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update quickMoveThread gadget to support the updated DOM structure in newer software versions by adjusting heading and anchor selectors.

Bug Fixes:
- Modify the heading selector to target h2 elements within .mw-heading containers.
- Change anchor ID retrieval to use the h2 element's id attribute directly.

</details>