### PR TITLE
fix(Gadget/noteTA): 与其它项目统一高度

### DIFF
--- a/src/gadgets/noteTA/Gadget-noteTA.js
+++ b/src/gadgets/noteTA/Gadget-noteTA.js
@@ -25,7 +25,7 @@ mw.hook("wikipage.content").add(() => {
             $("#p-noteTA-moeskin > button").addClass("noteTAViewer-button");
         } else {
             const noteTAIndicator = $("[id^=mw-indicator-noteTA-]").hide();
-            const $noteTAIndicatorImg = noteTAIndicator.find("img").attr("height", 17.5);
+            const $noteTAIndicatorImg = noteTAIndicator.find("img").css("height", "17.5px");
             $this = $("<div/>", {
                 "class": "vector-menu vector-menu-tabs",
                 id: "noteTA-vector-menu-tabs",


### PR DESCRIPTION
## Sourcery 总结

错误修复:
- 为 noteTA 指示器图片添加高度属性 17.5，以使其尺寸与其他项目统一。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add a height attribute of 17.5 to the noteTA indicator images to unify their size with other projects.

</details>