### PR TITLE
fix(Gadget/InPageEdit-v2): quickdiff button style

### DIFF
--- a/src/gadgets/InPageEdit-v2/Gadget-InPageEdit-v2.js
+++ b/src/gadgets/InPageEdit-v2/Gadget-InPageEdit-v2.js
@@ -44,5 +44,5 @@ mw.hook("InPageEdit").add((ctx) => {
             break;
         }
     }
-    $(".mw-history-compareselectedversions button").addClass('cdx-button');
+    $(".mw-history-compareselectedversions button").addClass("cdx-button");
 });

--- a/src/gadgets/InPageEdit-v2/Gadget-InPageEdit-v2.js
+++ b/src/gadgets/InPageEdit-v2/Gadget-InPageEdit-v2.js
@@ -44,4 +44,5 @@ mw.hook("InPageEdit").add((ctx) => {
             break;
         }
     }
+    $('.mw-history-compareselectedversions button').addClass('cdx-button');
 });

--- a/src/gadgets/InPageEdit-v2/Gadget-InPageEdit-v2.js
+++ b/src/gadgets/InPageEdit-v2/Gadget-InPageEdit-v2.js
@@ -44,5 +44,5 @@ mw.hook("InPageEdit").add((ctx) => {
             break;
         }
     }
-    $('.mw-history-compareselectedversions button').addClass('cdx-button');
+    $(".mw-history-compareselectedversions button").addClass('cdx-button');
 });


### PR DESCRIPTION
## Sourcery 总结

Bug 修复：
- 为历史比较按钮添加 `cdx-button` 类，以修复其样式

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add cdx-button class to the history compare button to fix its styling

</details>