### PR TITLE
fix(T:Info): compatible with dark mode

### DIFF
--- a/src/gadgets/site-styles/Gadget-site-styles.css
+++ b/src/gadgets/site-styles/Gadget-site-styles.css
@@ -408,7 +408,8 @@ s.just-kidding-text {
     background: #fbfbfb;
 }
 
-html.skin-theme-clientpref-night .infoBoxContent {
+html.skin-theme-clientpref-night .infoBoxContent,
+[color-mode="dark"] .infoBoxContent {
     border-color: #3e4452;
     background: #23272e;
 }

--- a/src/gadgets/site-styles/Gadget-site-styles.css
+++ b/src/gadgets/site-styles/Gadget-site-styles.css
@@ -408,15 +408,15 @@ s.just-kidding-text {
     background: #fbfbfb;
 }
 
+html.skin-theme-clientpref-night .infoBoxContent {
+    border-color: #3e4452;
+    background: #23272e;
+}
+
 .infoBoxBelow {
     margin: 0 auto;
     padding: 0;
     text-align: center;
-}
-
-[color-mode="dark"] .infoBoxContent {
-    border-color: #3e4452;
-    background: #23272e;
 }
 
 /* wikitable green */


### PR DESCRIPTION
`[color-mode="dark"]`在vector好像不行

## Sourcery 总结

改进：
- 替换已弃用的 `[color-mode="dark"] .infoBoxContent` 选择器为 `html.skin-theme-clientpref-night .infoBoxContent`，以支持深色主题

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Replace deprecated `[color-mode="dark"] .infoBoxContent` selector with `html.skin-theme-clientpref-night .infoBoxContent` for dark theme support

</details>