### PR TITLE
Potential fix for code scanning alert no. 125: Missing regular expression anchor

### DIFF
--- a/src/gadgets/interfaceVariantConverter/Gadget-interfaceVariantConverter.js
+++ b/src/gadgets/interfaceVariantConverter/Gadget-interfaceVariantConverter.js
@@ -17,7 +17,7 @@ $(() => (async () => {
 
     const pageid = mw.config.get("wgArticleId");
     const basepage = pagename.replace(/\/.*?$/, "");
-    const api = new mw.Api(), zhAPI = /^(m)?zh\.moegirl\.org\.cn$/.test(location.hostname) ? api : new mw.ForeignApi("https://mzh.moegirl.org.cn/api.php", { anonymous: true });
+    const api = new mw.Api(), zhAPI = /^m?zh\.moegirl\.org\.cn$/.test(location.hostname) ? api : new mw.ForeignApi("https://mzh.moegirl.org.cn/api.php", { anonymous: true });
 
     const lrAivc = $.extend({
         main: ["zh-cn", "zh-tw", "zh-hk"],


### PR DESCRIPTION
Potential fix for [https://github.com/MoegirlPediaInterfaceAdmins/MoegirlPediaInterfaceCodes/security/code-scanning/125](https://github.com/MoegirlPediaInterfaceAdmins/MoegirlPediaInterfaceCodes/security/code-scanning/125)

**General Fix:**  
Add regular expression anchors (`^` and `$`) to ensure matches only occur when `location.hostname` is *exactly* the expected value, or, if subdomains should be included, explicitly match against those.

**Detailed Fix:**  
Edit the regular expression passed to `.test()` for `location.hostname` (line 20). If both `mzh.moegirl.org.cn` and `zh.moegirl.org.cn` (without extra prefixes/suffixes) are valid, the expression should be `/^(m)?zh\.moegirl\.org\.cn$/` to avoid matching substrings in other hostnames.

**Where to Change:**  
In `src/gadgets/interfaceVariantConverter/Gadget-interfaceVariantConverter.js`, change line 20:
```js
const api = new mw.Api(), zhAPI = /m?zh\.moegirl\.org\.cn/.test(location.hostname) ? api : new mw.ForeignApi("https://mzh.moegirl.org.cn/api.php", { anonymous: true });
```
to:
```js
const api = new mw.Api(), zhAPI = /^(m)?zh\.moegirl\.org\.cn$/.test(location.hostname) ? api : new mw.ForeignApi("https://mzh.moegirl.org.cn/api.php", { anonymous: true });
```

**Dependencies/Imports:**  
No extra imports or dependencies needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Sourcery 总结

错误修复：
- 将主机名检测正则表达式限制为 `^(m)?zh\.moegirl\.org\.cn$` 以解决代码扫描警报编号 125

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

Bug 修复:
- 为 hostname 测试正则表达式添加 `^` 和 `$` 锚点，以防止不正确的子字符串匹配

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add ^ and $ anchors to the hostname test regex to prevent incorrect substring matches

</details>

</details>