### PR TITLE
fix: Potential fix for code scanning alert no. 166: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/detectHardcodedOutdatedNPMPackages.yaml
+++ b/.github/workflows/detectHardcodedOutdatedNPMPackages.yaml
@@ -1,4 +1,6 @@
 name: Detect hardcoded-outdated NPM packages
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/detectHardcodedOutdatedNPMPackages.yaml
+++ b/.github/workflows/detectHardcodedOutdatedNPMPackages.yaml
@@ -1,6 +1,7 @@
 name: Detect hardcoded-outdated NPM packages
 permissions:
   contents: read
+  issues: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/MoegirlPediaInterfaceAdmins/MoegirlPediaInterfaceCodes/security/code-scanning/166](https://github.com/MoegirlPediaInterfaceAdmins/MoegirlPediaInterfaceCodes/security/code-scanning/166)

The best way to fix this problem is to explicitly set a `permissions` block granting only the minimal necessary access for the job to function. Since the job does not appear to need write permissions (it only reads repo contents, installs dependencies, and runs a script), adding `permissions: contents: read` is sufficient. This block can be added either at the workflow root or to the specific job. Adding it at the root ensures all jobs (present and future) are covered, unless overridden on a per-job basis. The change should be made at the start of the workflow file, after `name:` and before `on:`.

No new imports, definitions, or dependencies are required—just an addition to the YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Sourcery 摘要

CI:
- 仅授予 `contents: read` 权限在工作流根目录，用于 `detectHardcodedOutdatedNPMPackages` job

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

CI:
- 在 `detectHardcodedOutdatedNPMPackages.yaml` 中，于工作流根目录添加权限块，内容为：`read`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Add permissions block with contents: read at the workflow root in detectHardcodedOutdatedNPMPackages.yaml

</details>

</details>