### PR TITLE
fix: Potential fix for code scanning alert no. 104: Useless assignment to local variable

### DIFF
--- a/src/gadgets/backlog/Gadget-backlog.js
+++ b/src/gadgets/backlog/Gadget-backlog.js
@@ -155,7 +155,7 @@ $(() => (async () => {
                         const expiryMoment = moment(expiry);
                         endTime = `<span title="${expiry}">${expiryMoment.format("YYYY[年]M[月]D[日 (]dd[)<br>]HH[:]mm[:]ss").replace(nowYear, "")}${now.diff(expiryMoment) > 0 ? "（已过期）" : ""}</span>`;
                     }
-                    let duration = loghidden ? loghiddenMsg : "";
+                    let duration;
                     if (_duration && !moment(_duration).isValid()) {
                         duration = "持续时间为";
                         if (/in(?:de)?finite|infinity|never/i.test(_duration)) {


### PR DESCRIPTION
Potential fix for [https://github.com/MoegirlPediaInterfaceAdmins/MoegirlPediaInterfaceCodes/security/code-scanning/104](https://github.com/MoegirlPediaInterfaceAdmins/MoegirlPediaInterfaceCodes/security/code-scanning/104)

The best fix is to remove the unnecessary initial assignment at line 158. This means deleting or updating the line `let duration = loghidden ? loghiddenMsg : "";` to instead declare the variable without assignment: `let duration;`. This correction does not alter any behavior, as the next usages of `duration` properly initialize it before any use. Edits are restricted to line 158 in `src/gadgets/backlog/Gadget-backlog.js`; nothing else needs adjustment.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Sourcery 总结

Bug 修复：
- 消除 Gadget-backlog.js 中 `duration` 不必要的默认赋值

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

错误修复：
- 消除 Gadget-backlog.js 中 `duration` 的冗余默认赋值，以解决代码扫描发现的问题

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Eliminate redundant default assignment for `duration` in Gadget-backlog.js to address code scanning finding

</details>

</details>