### PR TITLE
fix: Potential fix for code scanning alert no. 177: Semicolon insertion

### DIFF
--- a/scripts/postCommit/linguist-generated.js
+++ b/scripts/postCommit/linguist-generated.js
@@ -94,7 +94,7 @@ endGroup();
 const finalCodeQLConfig = {
     ...oldCodeQLConfig,
     "paths-ignore": codeQLConfigPathsIgnore,
-}
+};
 startGroup("final codeql-config.yaml:");
 console.info(finalCodeQLConfig);
 endGroup();


### PR DESCRIPTION
Potential fix for [https://github.com/MoegirlPediaInterfaceAdmins/MoegirlPediaInterfaceCodes/security/code-scanning/177](https://github.com/MoegirlPediaInterfaceAdmins/MoegirlPediaInterfaceCodes/security/code-scanning/177)

To fix the problem, an explicit semicolon should be added immediately after the closing brace `}` of the object literal assigned to `const finalCodeQLConfig`. This will prevent reliance on JavaScript's automatic semicolon insertion and maintain consistency with the rest of the codebase, which already uses explicit semicolons for statement termination.

- Only line 97 in `scripts/postCommit/linguist-generated.js` needs to be changed.
- No imports or other code modifications are required; only a semicolon should be appended.
- No functional change is introduced; this is purely a clarity and safety improvement.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

```chinese
## Sourcery 总结

增强功能：
- 在赋值给 `finalCodeQLConfig` 的对象字面量之后添加显式分号，以防止依赖自动分号插入
```

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

Bug 修复:
- 在赋值给 finalCodeQLConfig 的对象字面量后添加缺失的分号，以满足代码扫描警报并防止自动分号插入问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add missing semicolon after the object literal assigned to finalCodeQLConfig to satisfy code scanning alert and prevent automatic semicolon insertion issues

</details>

</details>