### PR TITLE
chore(Gadget/InPageEdit-v2): remove duplicate CSS

### DIFF
--- a/src/gadgets/InPageEdit-v2/Gadget-InPageEdit-v2.js
+++ b/src/gadgets/InPageEdit-v2/Gadget-InPageEdit-v2.js
@@ -55,5 +55,4 @@ mw.hook("InPageEdit").add((ctx) => {
             break;
         }
     }
-    $(".mw-history-compareselectedversions button").addClass("cdx-button");
 });


### PR DESCRIPTION
## Summary by Sourcery

改进：
- 消除在 InPageEdit v2 历史比较界面中重复应用按钮样式类的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Eliminate duplicate application of button styling classes in the InPageEdit v2 history comparison UI.

</details>