### PR TITLE
fix: navbar styles

### DIFF
--- a/src/gadgets/InPageEdit-v2/Gadget-InPageEdit-v2.css
+++ b/src/gadgets/InPageEdit-v2/Gadget-InPageEdit-v2.css
@@ -13,10 +13,6 @@
     display: none;
 }
 
-.noprint.plainlinks.hlist.navbar.nomobile {
-    width: 140px !important;
-}
-
 /* [[Special:Interwiki]] */
 .mw-interwikitable-modify .in-page-edit-article-link-group {
     display: none;

--- a/src/gadgets/inpageedit-next/Gadget-inpageedit-next.css
+++ b/src/gadgets/inpageedit-next/Gadget-inpageedit-next.css
@@ -2,10 +2,6 @@
  * 萌娘百科 InPageEdit-NEXT 本地样式修复
  */
 
-.noprint.plainlinks.hlist.navbar.nomobile {
-    width: 140px !important;
-}
-
 /* [[Special:Interwiki]] */
 .mw-interwikitable-modify .ipe-quick-edit {
     display: none;

--- a/src/gadgets/vector-2022-styles/Gadget-vector-2022-styles.css
+++ b/src/gadgets/vector-2022-styles/Gadget-vector-2022-styles.css
@@ -85,3 +85,7 @@ h2 {
     border-bottom: 1px solid #0074F9;
 }
 
+/* [[Template:Navbar]]意外换行 */
+.noprint.plainlinks.hlist.navbar.nomobile {
+    white-space: nowrap;
+}


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

调整导航栏样式，以防止出现非预期的换行，同时不在各个小工具之间强制使用固定宽度。

改进内容：
- 从 InPageEdit 和 InPageEdit-NEXT 小工具样式中移除导航栏元素的硬编码宽度覆盖设置。
- 在 Vector 2022 皮肤中为导航栏元素添加“禁止换行”的样式，以避免不必要的换行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust navbar styling to prevent unintended line breaks without forcing a fixed width across gadgets.

Enhancements:
- Remove hard-coded width override for navbar elements from InPageEdit and InPageEdit-NEXT gadget styles.
- Add a non-wrapping style for navbar elements in the Vector 2022 skin to avoid unwanted line wrapping.

</details>