### PR TITLE
feat: use icon instead of text for better appearance

### DIFF
--- a/src/gadgets/patrolCount/Gadget-patrolCount.js
+++ b/src/gadgets/patrolCount/Gadget-patrolCount.js
@@ -266,8 +266,8 @@ $(() => {
                         prepareList(pages, 10);
                         ttListShow = true;
                         const ctt = $("#patrollTooltip").cvtooltip({
-                            left: $(window).width() - ($("#pt-patroll").offset().left + $("#pt-patroll").outerWidth()),
-                            top: $("#pt-patroll").offset().top + $("#pt-patroll").height() + 10,
+                            left: $(window).width() - ($("#pt-patroll").offset().left + $("#pt-patroll").outerWidth() + 40),
+                            top: $("#pt-patroll").offset().top + $("#pt-patroll").outerHeight() + 10,
                             callback: () => {
                                 ttListShow = false;
                                 showAll = false;
@@ -446,13 +446,10 @@ $(() => {
     const ptPatrollLink = $("<a></a>", {
         href: "Special:最新页面?hidepatrolled=1",
         title: wgULS("最新页面", "最新頁面"),
-        text: wgULS("最新页面", "最新頁面"),
-    });
+    }).html(`<img src="/resources/lib/ooui/themes/wikimediaui/images/icons/article-rtl.svg" style="height:20px;margin:0 4px;" alt="${wgULS("最新页面", "最新頁面")}">`);
     $("#pt-watchlist-2").after($("<li></li>", {
         id: "pt-patroll",
-    }).append(ptPatrollLink).append($("<span></span>", {
-        id: "not-patrolled-count",
-    })));
+    }).append(ptPatrollLink));
     $("#pt-patroll").on("mouseover", updateUnpatrolled);
 });
 // </pre>


### PR DESCRIPTION
## Summary by Sourcery

将巡查链接文本替换为图标，并相应调整提示框的位置，以适配巡查计数小工具。

新功能：
- 在巡查计数小工具中，将巡查链接从文本显示改为图标显示。

增强改进：
- 调整提示框偏移量计算，使其能够与新的基于图标的巡查链接界面正确对齐。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace the patrol link text with an icon and adjust tooltip positioning accordingly for the patrol count gadget.

New Features:
- Display the patrol link as an icon instead of text in the patrol count gadget.

Enhancements:
- Adjust tooltip offset calculations to align correctly with the new icon-based patrol link UI.

</details>