### PR TITLE
feat: show count only when redirect exists

### DIFF
--- a/src/gadgets/queryWhatlinkshere/Gadget-queryWhatlinkshere.js
+++ b/src/gadgets/queryWhatlinkshere/Gadget-queryWhatlinkshere.js
@@ -119,7 +119,8 @@ $(() => (async () => {
             2303: { count: 0, redirect: 0 },
         };
         const global = { redirect: 0 };
-        whatlinkshere.text(`共有${list.length}个页面含有到本页面的站内链接（不考虑嵌入），其中有${list.filter((item) => Reflect.has(item, "redirect")).length}个重定向页面。`);
+        const redirectCount = list.filter((item) => Reflect.has(item, "redirect")).length;
+        whatlinkshere.text(`共有${list.length}个页面含有到本页面的站内链接（不考虑嵌入）${redirectCount > 0 ? `，其中有${redirectCount}个重定向页面。` : "。"}`);
         if (list.length > 0) {
             whatlinkshere.append("按命名空间划分如下：");
         }
@@ -131,7 +132,7 @@ $(() => (async () => {
                 global.redirect++;
             }
         });
-        Object.entries(nslist).filter(([, { count }]) => count > 0).sort(([a], [b]) => a - b).forEach(([nsnumber, { count, redirect }]) => ul.append(`<li>${upperFirstCase(nsids[nsnumber])}：${count}个页面（其中有${redirect}个重定向页面）`));
+        Object.entries(nslist).filter(([, { count }]) => count > 0).sort(([a], [b]) => a - b).forEach(([nsnumber, { count, redirect }]) => ul.append(`<li>${upperFirstCase(nsids[nsnumber])}：${count}个页面${redirect > 0 ? `（其中有${redirect}个重定向页面）` : ""}`));
         whatlinkshere.after(ul);
     });
     queryWhatembeddedin.on("click", async () => {


### PR DESCRIPTION
## Summary by Sourcery

调整 whatlinkshere 小工具的消息显示逻辑，仅在存在重定向时显示重定向计数。

Enhancements:
- 当没有重定向时，在整体的 whatlinkshere 摘要中隐藏重定向计数文本。
- 当某个命名空间的重定向数为零时，在 whatlinkshere 列表项中隐藏该命名空间的重定向计数详情。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust whatlinkshere gadget messaging to only display redirect counts when redirects are present.

Enhancements:
- Hide redirect count text in the overall whatlinkshere summary when there are no redirects.
- Hide per-namespace redirect count details in the whatlinkshere list items when a namespace has zero redirects.

</details>