### PR TITLE
fix(Global/Vector-2022): :bug: Site notice scrolling

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -27,3 +27,4 @@ Dreammu <84692291+dreammu@users.noreply.github.com>
 SaoMikoto <Saoutax@outlook.com>
 LJL <ljlorljl@163.com>
 SaoMikoto <Saoutax@gmail.com>
+GuoPC <gpc2843661009@gmail.com>

--- a/src/global/zh/Vector-2022.js
+++ b/src/global/zh/Vector-2022.js
@@ -8,7 +8,7 @@
     /* 函数定义体 */
     /* 滚动公告 */
     const startScroll = () => {
-        $("body > #content > #siteNotice .scrollDiv:not(.scrolling), #moe-sitenotice-container > .moe-sitenotice .scrollDiv:not(.scrolling)").addClass("scrolling").each((_, ele) => {
+        $(".vector-sitenotice-container > #siteNotice .scrollDiv:not(.scrolling), #moe-sitenotice-container > .moe-sitenotice .scrollDiv:not(.scrolling)").addClass("scrolling").each((_, ele) => {
             const self = $(ele);
             self.children().each((_, child) => {
                 if (child.innerHTML.trim() === "") {
@@ -29,7 +29,7 @@
     const autoScroll = () => {
         setInterval(() => {
             if (!document.hidden) {
-                $("body > #content > #siteNotice .scrollDiv.scrolling, #moe-sitenotice-container > .moe-sitenotice .scrollDiv.scrolling").each((_, ele) => {
+                $(".vector-sitenotice-container > #siteNotice .scrollDiv.scrolling, #moe-sitenotice-container > .moe-sitenotice .scrollDiv.scrolling").each((_, ele) => {
                     const self = $(ele);
                     if (self.css("font-weight") === "700") {
                         return;


### PR DESCRIPTION
Change selectors to fix site notice scrolling under Vector-2022.

## Summary by Sourcery

错误修复：
- 修复由于使用过期的 DOM 选择器，导致在 Vector-2022 布局下站点通知的自动滚动未生效的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix site notice auto-scrolling not applying under the Vector-2022 layout due to outdated DOM selectors.

</details>