### PR TITLE
feat(Gadget/SideBarPic): 统一透明背景

### DIFF
--- a/src/gadgets/SideBarPic/Gadget-SideBarPic.css
+++ b/src/gadgets/SideBarPic/Gadget-SideBarPic.css
@@ -55,7 +55,9 @@ body.sideBarPic:not(.DeceasedPerson) #footer #footer-moegirl .copyright {
 }
 
 /* vector-2022 背景图片 */
-body.sideBarPic.skin-vector-2022.mediawiki .mw-page-container {
+body.sideBarPic.skin-vector-2022.mediawiki .mw-page-container,
+body.sideBarPic .vector-header-container .mw-header,
+body.sideBarPic .vector-dropdown .vector-dropdown-content {
     background-color: rgb(255 255 255 / 90%);
 }
 
@@ -66,9 +68,4 @@ body.sideBarPic .vector-pinned-container {
 
 body.sideBarPic .vector-sticky-pinned-container::after {
     display: none;
-}
-
-body.sideBarPic .vector-header-container .mw-header,
-body.sideBarPic .vector-dropdown .vector-dropdown-content {
-    background-color: rgb(255 255 255 / 90%);
 }


### PR DESCRIPTION
## Summary by Sourcery

统一 SideBarPic 小工具中 Vector 头部和下拉内容的半透明白色背景样式。

增强内容：
- 为 Vector 头部栏应用一致的半透明白色背景。
- 为 SideBarPic 小工具中的 Vector 下拉菜单应用一致的半透明白色背景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify the translucent white background styling for the Vector header and dropdown content in the SideBarPic gadget.

Enhancements:
- Apply a consistent semi-transparent white background to the Vector header bar.
- Apply a consistent semi-transparent white background to Vector dropdown menus in the SideBarPic gadget.

</details>