### PR TITLE
fix(Gadget/moveToUserSubpage): ignore `moderation-move-queued`

### DIFF
--- a/src/gadgets/moveToUserSubpage/Gadget-moveToUserSubpage.js
+++ b/src/gadgets/moveToUserSubpage/Gadget-moveToUserSubpage.js
@@ -257,11 +257,7 @@ $(() => {
                         throw moveRes;
                     }
                 } catch (e) {
-                    if (typeof e.error?.code === "string") {
-                        if (e.error.code !== "moderation-move-queued") {
-                            throw e.error;
-                        }
-                    } else {
+                    if (e !== "moderation-move-queued") {
                         throw e;
                     }
                 }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 在移动操作期间，正确忽略 `"moderation-move-queued"` 响应，而不是将其作为错误抛出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correctly ignore the "moderation-move-queued" response instead of throwing it as an error during move operations.

</details>