### PR TITLE
feat: move button to sidebar

### DIFF
--- a/src/gadgets/wikiBlame/Gadget-wikiBlame.js
+++ b/src/gadgets/wikiBlame/Gadget-wikiBlame.js
@@ -3,7 +3,7 @@
 /* eslint-disable no-use-before-define */
 "use strict";
 $(() => {
-    if (!mw.config.get("wgIsArticle") || !mw.config.get("wgArticleId") || mw.config.get("wgAction") !== "view") {
+    if (!mw.config.get("wgIsArticle") || !mw.config.get("wgArticleId")) {
         return;
     }
 


### PR DESCRIPTION
## Summary by Sourcery

将 wikiBlame 触发方式从内联选区弹出框移动到持久存在的侧边栏操作，并将该小工具限制为仅在条目查看页面生效。

新功能：
- 在页面侧边栏中添加一个 wikiBlame 操作链接，用于对选中文本执行 blame 操作。

增强改进：
- 移除基于 mouseup 事件的正文内联弹出按钮，改为使用侧边栏入口。
- 通过在初始化前检查页面操作类型，确保 wikiBlame 小工具仅在条目查看页面上运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Move the wikiBlame trigger from inline selection popups to a persistent sidebar action and restrict the gadget to article view pages.

New Features:
- Add a wikiBlame action link to the page sidebar for invoking blame on selected text.

Enhancements:
- Remove the mouseup-based inline popup button in the article body in favor of a sidebar entry.
- Ensure the wikiBlame gadget only runs on article view pages by checking the page action before initialization.

</details>