### PR TITLE
fix(Gadget/mwPanel): prefixindex should not show in ns--1

### DIFF
--- a/src/gadgets/mwPanel/Gadget-mwPanel.css
+++ b/src/gadgets/mwPanel/Gadget-mwPanel.css
@@ -1,0 +1,14 @@
+#t-expandtemplates,
+#t-userlog,
+.ns-2 #t-pagelog,
+.ns-3 #t-pagelog,
+.ns--1 #t-pagelog,
+.ns--1 #t-prefixindex {
+    display: none;
+}
+
+.ns-10 #t-expandtemplates,
+.ns-2 #t-userlog,
+.ns-3 #t-userlog {
+    display: list-item !important;
+}

--- a/src/gadgets/mwPanel/Gadget-mwPanel.js
+++ b/src/gadgets/mwPanel/Gadget-mwPanel.js
@@ -21,7 +21,6 @@ $(() => {
             }
         }
     }
-    mw.loader.addStyleTag("#t-expandtemplates, #t-userlog, .ns-2 #t-pagelog, .ns-3 #t-pagelog, .ns--1 #t-pagelog, .ns--1 #t-prefixindex {display:none;}.ns-10 #t-expandtemplates, .ns-2 #t-userlog, .ns-3 #t-userlog {display:list-item!important;}");
     $("#t-log a").text(wgULS("用户日志", "使用者日誌", null, null, "用戶日誌"));
 });
 // </pre>

--- a/src/gadgets/mwPanel/definition.yaml
+++ b/src/gadgets/mwPanel/definition.yaml
@@ -35,3 +35,4 @@ _section: skin
 
 _files:
   - Gadget-mwPanel.js
+  - Gadget-mwPanel.css


### PR DESCRIPTION
## Summary by Sourcery

将 mwPanel 小工具链接的可见性规则从内联 JavaScript 移动到独立的样式表中，并在特殊命名空间 (-1) 中隐藏 prefixindex 链接。

Bug 修复：
- 在特殊命名空间 (-1) 中隐藏 prefixindex 侧边栏链接，防止其出现在不应显示的位置。

增强内容：
- 将 mwPanel 小工具脚本中的内联 CSS 抽取到单独的 `Gadget-mwPanel.css` 文件中，并通过小工具定义引用该文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Move mwPanel gadget link visibility rules from inline JavaScript to a dedicated stylesheet and hide the prefixindex link in the special (-1) namespace.

Bug Fixes:
- Hide the prefixindex sidebar link in the special (-1) namespace to prevent it from showing where it should not.

Enhancements:
- Extract inline CSS from the mwPanel gadget script into a separate Gadget-mwPanel.css file referenced by the gadget definition.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 mwPanel 小工具链接的可见性规则从内联 JavaScript 移动到独立的样式表中，并在特殊命名空间 (-1) 中隐藏 prefixindex 链接。

Bug 修复：
- 在特殊命名空间 (-1) 中隐藏 prefixindex 侧边栏链接，防止其出现在不应显示的位置。

增强内容：
- 将 mwPanel 小工具脚本中的内联 CSS 抽取到单独的 `Gadget-mwPanel.css` 文件中，并通过小工具定义引用该文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Move mwPanel gadget link visibility rules from inline JavaScript to a dedicated stylesheet and hide the prefixindex link in the special (-1) namespace.

Bug Fixes:
- Hide the prefixindex sidebar link in the special (-1) namespace to prevent it from showing where it should not.

Enhancements:
- Extract inline CSS from the mwPanel gadget script into a separate Gadget-mwPanel.css file referenced by the gadget definition.

</details>

</details>