### PR TITLE
chore(Gadget/float-toc): disable gadget as it's useless in vector-2022

### DIFF
--- a/src/gadgets/float-toc/definition.yaml
+++ b/src/gadgets/float-toc/definition.yaml
@@ -38,6 +38,7 @@ package: false
 
 rights:
   - autoconfirmed
+  - disabled
 
 peers: []
 


### PR DESCRIPTION
## Summary by Sourcery

增强功能：
- 更新 float-toc gadget 权限配置，以包含一个禁用标志（disabled flag）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Update float-toc gadget rights configuration to include a disabled flag.

</details>