### PR TITLE
Fix page info

### DIFF
--- a/src/gadgets/pageInfo/Gadget-pageInfo.css
+++ b/src/gadgets/pageInfo/Gadget-pageInfo.css
@@ -29,7 +29,7 @@
     cursor: default !important;
 }
 
-.vector-menu-content-list .page-info-container .annotation-content {
+.vector-menu-content-list .page-info-container .page-info-annotation-content {
     cursor: text !important;
 }
 

--- a/src/gadgets/pageInfo/Gadget-pageInfo.js
+++ b/src/gadgets/pageInfo/Gadget-pageInfo.js
@@ -57,7 +57,7 @@
             protectionInfo.push(`${mw.msg("create")}：${wgRestrictionCreate.map((level) => mw.msg(`protect-level-${level}`)).join("、")}`);
         }
         const $protectionInfoContainer = $("<a>", {
-            "class": "page-info-protection annotation",
+            "class": "page-info-protection page-info-annotation",
         });
         $protectionInfoContainer.appendTo($container);
         const $protectionInfoImage = $("<img>", {
@@ -65,7 +65,7 @@
         });
         $protectionInfoImage.appendTo($protectionInfoContainer);
         const $protectionInfoText = $("<span>", {
-            "class": "annotation-content",
+            "class": "page-info-annotation-content",
             html: [
                 `<b>${wgULS("页面受到以下保护：", "頁面受到以下保護：")}</b>`,
                 ...protectionInfo,


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

增强内容：
- 重命名页面信息小工具和样式表中的保护信息链接和文本 CSS 类，以使用一致的、特定于 page-info 的注释命名方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Rename protection info link and text CSS classes in the page info gadget and stylesheet to use a consistent page-info-specific annotation naming.

</details>