### PR TITLE
chore: 统一滥用过滤器译名

### DIFF
--- a/src/gadgets/abusefilter33test/Gadget-abusefilter33test.js
+++ b/src/gadgets/abusefilter33test/Gadget-abusefilter33test.js
@@ -121,7 +121,7 @@ $(() => (async () => {
             }
             table.empty();
             if (result.length > 0) {
-                table.append(`<caption style="font-weight: 700;">命中防滥用过滤器${filter}的内容</caption><tr><th style="text-align: right;">规则（请勿泄漏！！！）</th><th style="text-align: left;">命中字符串上下文</th></tr>`);
+                table.append(`<caption style="font-weight: 700;">命中滥用过滤器${filter}的内容</caption><tr><th style="text-align: right;">规则（请勿泄漏！！！）</th><th style="text-align: left;">命中字符串上下文</th></tr>`);
                 result.sort(({ start: a }, { start: b }) => a - b);
                 const results = [];
                 result.forEach((r) => {

--- a/src/gadgets/abusefilterEdit/Gadget-abusefilteredit.css
+++ b/src/gadgets/abusefilterEdit/Gadget-abusefilteredit.css
@@ -1,4 +1,4 @@
-/* 防滥用过滤器编辑页 */
+/* 滥用过滤器编辑页 */
 #mw-abusefilter-warn-parameters fieldset,
 #mw-abusefilter-warn-parameters table {
     width: 100%;

--- a/src/gadgets/abusefilterEdit/Gadget-abusefilteredit.js
+++ b/src/gadgets/abusefilterEdit/Gadget-abusefilteredit.js
@@ -19,7 +19,7 @@ $(() => {
             select = self.find("select").appendTo(self);
         let MWFP, MAWP, MWFC, MWFO;
         self.find("td").remove();
-        self.append('<td><fieldset><legend>使用现有的消息</legend><table><tr><td class="mw-label">用作警告的系统消息：</td><td class="mw-input" id="mw-abusefilter-edit-warn-message-select"></td></tr><tr><td class="mw-label">操作：</td><td class="mw-input"><p><input id="MWFP" type="button" value="预览消息"><input id="MWFC" type="button" value="清空预览" style="display: none;"><input id="MWFO" type="button" value="在新窗口打开"> </p></td></tr><tr><td id="MAWP" colspan="2"></td></tr><tr><td colspan="2"><p>P.S.只有这里的下拉栏设置的系统消息才是防滥用过滤器使用的系统消息，隔壁是创建用啦！</p></td></tr><tr><td colspan="2" id="MAWI"></td></tr></table></fieldset></td>').find("#mw-abusefilter-edit-warn-message-select").append(select);
+        self.append('<td><fieldset><legend>使用现有的消息</legend><table><tr><td class="mw-label">用作警告的系统消息：</td><td class="mw-input" id="mw-abusefilter-edit-warn-message-select"></td></tr><tr><td class="mw-label">操作：</td><td class="mw-input"><p><input id="MWFP" type="button" value="预览消息"><input id="MWFC" type="button" value="清空预览" style="display: none;"><input id="MWFO" type="button" value="在新窗口打开"> </p></td></tr><tr><td id="MAWP" colspan="2"></td></tr><tr><td colspan="2"><p>P.S.只有这里的下拉栏设置的系统消息才是滥用过滤器使用的系统消息，隔壁是创建用啦！</p></td></tr><tr><td colspan="2" id="MAWI"></td></tr></table></fieldset></td>').find("#mw-abusefilter-edit-warn-message-select").append(select);
         MWFP = $("#MWFP"), MAWP = $("#MAWP"), MWFC = $("#MWFC"), MWFO = $("#MWFO");
         MAWI = $("#MAWI"), selectOpt = select.html(), selectVal = select.val(); // 放置到上级作用域链以便其他元素执行
         MWFP.on("click", () => {

--- a/src/groups/zh/sysop/Group-sysop.js
+++ b/src/groups/zh/sysop/Group-sysop.js
@@ -12,7 +12,7 @@
             reasonPageName = href.slice(href.indexOf("title=") + 6, href.indexOf("&action"));
         $obj.before(`<a target="_blank" href="/${reasonPageName}">浏览${act}原因</a>`);
     };
-    // 防滥用过滤器相关
+    // 滥用过滤器相关
     // eslint-disable-next-line no-unused-vars
     const abuseLog = () => {
         if ($(".mw-special-AbuseLog")[0]) {
@@ -57,7 +57,7 @@
                     },
                 });
                 $('form[action="/Special:%E6%BB%A5%E7%94%A8%E6%97%A5%E5%BF%97"] > fieldset').append("<p/>").find("p").append($("<span/>", {
-                    text: `点击隐藏/显示防滥用过滤器${Array.from(needToggle.values()).join("、").replace(/、(?=[^、]+$)/, "和")}的日志：`,
+                    text: `点击隐藏/显示滥用过滤器${Array.from(needToggle.values()).join("、").replace(/、(?=[^、]+$)/, "和")}的日志：`,
                 })).append(input);
                 if (lastStatus) {
                     body.addClass("AbuseFilterHidden");
@@ -65,7 +65,7 @@
             }
         }
     };
-    // 防滥用过滤器列表
+    // 滥用过滤器列表
     const AbuseList = () => {
         const idList = $(".TablePager_col_af_id a"),
             // lvList = $(".TablePager_col_af_hidden"),
@@ -111,9 +111,9 @@
     if (mw.config.get("wgCanonicalSpecialPageName") === "Revisiondelete" && $(".mw-revdel-editreasons")[0]) {
         addLink($(".mw-revdel-editreasons > a"), "删除");
     }
-    // 防滥用过滤器日志
+    // 滥用过滤器日志
     // abuseLog();
-    // 防滥用过滤器列表
+    // 滥用过滤器列表
     if (mw.config.get("wgPageName") === "Special:滥用过滤器") {
         AbuseList();
     }


### PR DESCRIPTION
## Summary by Sourcery

增强内容：
- 在系统管理员工具和 AbuseFilter 小工具中，将所有面向用户的标签和注释统一从“防滥用过滤器”更改为“滥用过滤器”。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Unify user-facing labels and comments from “防滥用过滤器” to “滥用过滤器” across sysop tools and AbuseFilter gadgets.

</details>