### PR TITLE
fix: 文字缺失

### DIFF
--- a/src/gadgets/queryWhatlinkshere/Gadget-queryWhatlinkshere.js
+++ b/src/gadgets/queryWhatlinkshere/Gadget-queryWhatlinkshere.js
@@ -103,7 +103,7 @@ $(() => (async () => {
                 global.redirect++;
             }
         });
-        Object.entries(nslist).filter(([, { count }]) => count > 0).sort(([a], [b]) => a - b).forEach(([nsnumber, { count, redirect }]) => ul.append(`<li>${nsnumber === 0 ? mw.msg("blanknamespace") : upperFirstCase(libLocalizedNamespaces[nsnumber])}：${count}个页面${redirect > 0 ? `（其中有${redirect}个重定向页面）` : ""}`));
+        Object.entries(nslist).filter(([, { count }]) => count > 0).sort(([a], [b]) => a - b).forEach(([nsnumber, { count, redirect }]) => ul.append(`<li>${Number(nsnumber) === 0 ? mw.msg("blanknamespace") : upperFirstCase(libLocalizedNamespaces[nsnumber])}：${count}个页面${redirect > 0 ? `（其中有${redirect}个重定向页面）` : ""}`));
         whatlinkshere.after(ul);
     });
     queryWhatembeddedin.on("click", async () => {
@@ -201,7 +201,7 @@ $(() => (async () => {
             nslist[ns].redirect.push(title);
             global.redirect++;
         });
-        Object.entries(nslist).filter(([, { count }]) => count > 0).sort(([a], [b]) => a - b).forEach(([nsnumber, { count, redirect }]) => ul.append(`<li class="mw-parser-output">${nsnumber === 0 ? mw.msg("blanknamespace") : upperFirstCase(libLocalizedNamespaces[nsnumber])}：${count}个页面${redirect.length > 0 ? `（其中有${redirect.length}个重定向页面：${redirect.map((title) => `<a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="/index.php?title=${encodeURIComponent(title)}&amp;redirect=no">${title}</a>`).join("、")}）` : ""}`));
+        Object.entries(nslist).filter(([, { count }]) => count > 0).sort(([a], [b]) => a - b).forEach(([nsnumber, { count, redirect }]) => ul.append(`<li class="mw-parser-output">${Number(nsnumber) === 0 ? mw.msg("blanknamespace") : upperFirstCase(libLocalizedNamespaces[nsnumber])}：${count}个页面${redirect.length > 0 ? `（其中有${redirect.length}个重定向页面：${redirect.map((title) => `<a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="/index.php?title=${encodeURIComponent(title)}&amp;redirect=no">${title}</a>`).join("、")}）` : ""}`));
         whatembeddedin.after(ul);
     });
 })());

--- a/src/gadgets/queryWhatlinkshere/Gadget-queryWhatlinkshere.js
+++ b/src/gadgets/queryWhatlinkshere/Gadget-queryWhatlinkshere.js
@@ -103,7 +103,7 @@ $(() => (async () => {
                 global.redirect++;
             }
         });
-        Object.entries(nslist).filter(([, { count }]) => count > 0).sort(([a], [b]) => a - b).forEach(([nsnumber, { count, redirect }]) => ul.append(`<li>${upperFirstCase(libLocalizedNamespaces[nsnumber])}：${count}个页面${redirect > 0 ? `（其中有${redirect}个重定向页面）` : ""}`));
+        Object.entries(nslist).filter(([, { count }]) => count > 0).sort(([a], [b]) => a - b).forEach(([nsnumber, { count, redirect }]) => ul.append(`<li>${nsnumber === 0 ? mw.msg("blanknamespace") : upperFirstCase(libLocalizedNamespaces[nsnumber])}：${count}个页面${redirect > 0 ? `（其中有${redirect}个重定向页面）` : ""}`));
         whatlinkshere.after(ul);
     });
     queryWhatembeddedin.on("click", async () => {
@@ -201,7 +201,7 @@ $(() => (async () => {
             nslist[ns].redirect.push(title);
             global.redirect++;
         });
-        Object.entries(nslist).filter(([, { count }]) => count > 0).sort(([a], [b]) => a - b).forEach(([nsnumber, { count, redirect }]) => ul.append(`<li class="mw-parser-output">${upperFirstCase(libLocalizedNamespaces[nsnumber])}：${count}个页面${redirect.length > 0 ? `（其中有${redirect.length}个重定向页面：${redirect.map((title) => `<a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="/index.php?title=${encodeURIComponent(title)}&amp;redirect=no">${title}</a>`).join("、")}）` : ""}`));
+        Object.entries(nslist).filter(([, { count }]) => count > 0).sort(([a], [b]) => a - b).forEach(([nsnumber, { count, redirect }]) => ul.append(`<li class="mw-parser-output">${nsnumber === 0 ? mw.msg("blanknamespace") : upperFirstCase(libLocalizedNamespaces[nsnumber])}：${count}个页面${redirect.length > 0 ? `（其中有${redirect.length}个重定向页面：${redirect.map((title) => `<a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="/index.php?title=${encodeURIComponent(title)}&amp;redirect=no">${title}</a>`).join("、")}）` : ""}`));
         whatembeddedin.after(ul);
     });
 })());


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 在 `queryWhatlinkshere` 和 `queryWhatembeddedin` 的结果中，为主（空）命名空间显示正确的本地化标签，而不是留空。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Display the correct localized label for the main (blank) namespace instead of leaving it empty in queryWhatlinkshere and queryWhatembeddedin results.

</details>