### PR TITLE
feat: 隐藏前缀索引的用户徽章

### DIFF
--- a/src/gadgets/site-styles/Gadget-site-styles.css
+++ b/src/gadgets/site-styles/Gadget-site-styles.css
@@ -1495,6 +1495,8 @@ body.mw-special-Log .mw-htmlform-flatlist > .oo-ui-fieldLayout:nth-child(4) {
 .mw-title moe-badge,
 .mw-enhanced-rc-time moe-badges,
 .mw-enhanced-rc-time moe-badge,
+.mw-prefixindex-list moe-badges,
+.mw-prefixindex-list moe-badge,
 #mw-content-subtitle moe-badges {
     display: none;
 }


### PR DESCRIPTION
## Summary by Sourcery

增强功能：
- 扩展现有的 CSS 规则，以在前缀索引结果列表中同时隐藏 `moe-badges` 和 `moe-badge` 元素。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Extend existing CSS rules to also hide moe-badges and moe-badge elements within prefix index result lists.

</details>