### PR TITLE
feat: 隐藏Special:AllPages的用户徽章

### DIFF
--- a/src/gadgets/site-styles/Gadget-site-styles.css
+++ b/src/gadgets/site-styles/Gadget-site-styles.css
@@ -1497,6 +1497,8 @@ body.mw-special-Log .mw-htmlform-flatlist > .oo-ui-fieldLayout:nth-child(4) {
 .mw-enhanced-rc-time moe-badge,
 .mw-prefixindex-list moe-badges,
 .mw-prefixindex-list moe-badge,
+.mw-allpages-body moe-badges,
+.mw-allpages-body moe-badge,
 #mw-content-subtitle moe-badges {
     display: none;
 }


### PR DESCRIPTION
## Summary by Sourcery

增强内容：
- 扩展现有样式，以在 Special:AllPages 布局中隐藏 `moe-badge`/`moe-badges` 元素。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Extend existing styles to hide moe-badge/moe-badges elements within the Special:AllPages layout.

</details>