### PR TITLE
fix: update visibility styles and remove unneeded text in userpageDelete gadget

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -28,3 +28,4 @@ SaoMikoto <Saoutax@outlook.com>
 LJL <ljlorljl@163.com>
 SaoMikoto <Saoutax@gmail.com>
 GuoPC <gpc2843661009@gmail.com>
+默默无闻的杜邦线 <75931686+Kelly-Hsueh@users.noreply.github.com>

--- a/src/gadgets/userpageDelete/Gadget-userpageDelete.js
+++ b/src/gadgets/userpageDelete/Gadget-userpageDelete.js
@@ -90,11 +90,6 @@ $(() => {
 
         const windowManager = new OO.ui.WindowManager();
         $body.append(windowManager.$element);
-        const ns2dDialog = new Ns2dWindow({
-            size: "medium",
-            text: "test",
-        });
-        windowManager.addWindows([ns2dDialog]);
 
         $(mw.util.addPortletLink("p-cactions", "#", wgULS("自助删除", "自助刪除"), "ca-lr-ns2d", `${wgULS("自助删除用户页面", "自助刪除使用者頁面", null, null, "自助刪除用戶頁面")}`)).on("click", (e) => {
             e.preventDefault();

--- a/src/gadgets/userpageDelete/Gadget-userpageDelete.js
+++ b/src/gadgets/userpageDelete/Gadget-userpageDelete.js
@@ -90,6 +90,10 @@ $(() => {
 
         const windowManager = new OO.ui.WindowManager();
         $body.append(windowManager.$element);
+        const ns2dDialog = new Ns2dWindow({
+            size: "medium",
+        });
+        windowManager.addWindows([ns2dDialog]);
 
         $(mw.util.addPortletLink("p-cactions", "#", wgULS("自助删除", "自助刪除"), "ca-lr-ns2d", `${wgULS("自助删除用户页面", "自助刪除使用者頁面", null, null, "自助刪除用戶頁面")}`)).on("click", (e) => {
             e.preventDefault();

--- a/src/groups/zh/sysop/Group-sysop.js
+++ b/src/groups/zh/sysop/Group-sysop.js
@@ -76,12 +76,12 @@
             while ($ele.text().length + zero.length < idLength) {
                 zero += "0";
             }
-            $ele.prepend(`<span style="speak:none;visibility:hidden;color:transparent;">${zero}</span>`);
+            $ele.prepend(`<span style="visibility:hidden;">${zero}</span>`);
         });
         /* lvList.each((_, ele) => {
             const $ele = $(ele);
             if ($ele.text().length === 2) {
-                $ele.prepend('<span style="speak:none;visibility:hidden;color:transparent;">已</span>');
+                $ele.prepend('<span style="visibility:hidden;">已</span>');
             }
         }); */
     };


### PR DESCRIPTION
- 删除了 Gadget-userpageDelete.js 中测试用弹窗相关代码
- 简化了 Group-sysop.js 中用于隐藏文本的内联样式，移除了不必要的属性

## 由 Sourcery 提供的总结

从用户页删除小工具中移除已废弃的测试对话框，并为 zh 管理员组简化隐藏文本样式。

错误修复：
- 更正 zh 管理员组界面中的隐藏文本样式，使其仅依赖可见性规则。

功能改进：
- 从 userpageDelete 小工具中移除未使用的测试对话框设置，以清理代码库。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove obsolete test dialog from the userpage deletion gadget and simplify hidden text styling for the zh sysop group.

Bug Fixes:
- Correct hidden text styling in the zh sysop group UI to rely only on visibility rules.

Enhancements:
- Remove unused test dialog setup from the userpageDelete gadget to clean up the codebase.

</details>