### PR TITLE
feat(Gadget/pageInfo): add preloadparams[] and dtpreload for request links

### DIFF
--- a/src/gadgets/pageInfo/Gadget-pageInfo.js
+++ b/src/gadgets/pageInfo/Gadget-pageInfo.js
@@ -9,21 +9,26 @@
         $container.append($("<br>"), document.createTextNode(`${mw.msg(action)}：${levels.map((level) => mw.msg(`protect-level-${level}`)).join("、")}`), $requestList);
         return $requestList;
     };
-    const buildRequestUrl = ({ title, preload, preloadTitle, scriptPath }) => {
+    const buildRequestUrl = ({ title, preload, preloadTitle, preloadParams, scriptPath }) => {
         const requestURL = new URL(`${scriptPath}/index.php`, location.origin);
         requestURL.searchParams.set("action", "edit");
         requestURL.searchParams.set("preload", preload);
         requestURL.searchParams.set("preloadtitle", preloadTitle);
+        requestURL.searchParams.set("dtpreload", "1");
         requestURL.searchParams.set("section", "new");
         requestURL.searchParams.set("title", title);
+        if (Array.isArray(preloadParams)) {
+            preloadParams.forEach((param) => requestURL.searchParams.append("preloadparams[]", param));
+        }
         return requestURL.href;
     };
-    const appendRequestLink = ($list, { title, preload, preloadTitle, scriptPath, text }) => {
+    const appendRequestLink = ($list, { title, preload, preloadTitle, preloadParams, scriptPath, text }) => {
         $("<li>").append($("<a>", {
             href: buildRequestUrl({
                 title,
                 preload,
                 preloadTitle,
+                preloadParams,
                 scriptPath,
             }),
             target: "_blank",
@@ -148,6 +153,7 @@
                     title: "萌娘百科讨论:讨论版/操作申请",
                     preload: "Template:移动请求预载",
                     preloadTitle: `移动请求${requestTitleSuffix}`,
+                    preloadParams: [wgPageName],
                     scriptPath: wgScriptPath,
                     text: "提出移动请求",
                 });
@@ -159,6 +165,7 @@
                     title: "萌娘百科讨论:讨论版/操作申请",
                     preload: "Template:创建请求预载",
                     preloadTitle: `创建请求${requestTitleSuffix}`,
+                    preloadParams: [wgPageName],
                     scriptPath: wgScriptPath,
                     text: "提出创建请求",
                 });


### PR DESCRIPTION
- Added support for passing `preloadparams[]` (current page title) to the move/create request preload link so `Template:移动请求预载` and `Template:创建请求预载` can receive the original title as a parameter.
- Append `dtpreload=1` to the request URL so DiscussionTools (new-topic tool) will open the composer when available; falls back harmlessly when not installed.

## Summary by Sourcery

增强页面信息 gadget 的请求链接，使其在预加载参数中传递当前页面标题，并在可用时触发 DiscussionTools 的新话题编辑器（new-topic composer）。

新功能：
- 为移动（move）和创建请求的预加载链接添加对 `preloadparams[]`（包括当前页面标题）的支持，以便预加载模板可以接收原始标题。
- 在请求 URL 中追加 `dtpreload=1`，从而在可用时让 DiscussionTools 的新话题工具自动打开编辑器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance page info gadget request links to pass the current page title as preload parameters and trigger DiscussionTools new-topic composer when available.

New Features:
- Add support for passing preloadparams[] (including the current page title) to move and create request preload links so preload templates can receive the original title.
- Append dtpreload=1 to request URLs so DiscussionTools new-topic tool automatically opens the composer when available.

</details>