### PR TITLE
feat: 新增发布草稿小工具

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -142,6 +142,7 @@
         "Gadget/prism-plugin-match-braces",
         "Gadget/prism-plugin-phpdoc",
         "Gadget/prism-plugin-previewers",
+        "Gadget/publishDraft",
         "Gadget/Purgecache",
         "Gadget/queryContributions",
         "Gadget/queryWhatlinkshere",

--- a/src/gadgets/Gadgets-definition-list.yaml
+++ b/src/gadgets/Gadgets-definition-list.yaml
@@ -76,6 +76,7 @@
     - uploader
     - temp-editcheck
     - wikiplus-highlight
+    - publishDraft
 
 - name: maintenance
   gadgets:

--- a/src/gadgets/publishDraft/Gadget-publishDraft.js
+++ b/src/gadgets/publishDraft/Gadget-publishDraft.js
@@ -1,0 +1,95 @@
+"use strict";
+$(() => {
+    const { wgNamespaceNumber, wgArticleId, wgPageName, wgTitle } = mw.config.get([
+        "wgNamespaceNumber",
+        "wgArticleId",
+        "wgPageName",
+        "wgTitle",
+    ]);
+
+    if (wgNamespaceNumber !== 118 || wgArticleId === 0) {
+        return;
+    }
+    const api = new mw.Api();
+
+    const removeTemplate = async () => {
+        const {
+            query: {
+                pages: [
+                    {
+                        revisions: [{ content }],
+                    },
+                ],
+            },
+        } = await api.post({
+            action: "query",
+            prop: "revisions",
+            rvprop: "content",
+            titles: wgPageName,
+            formatversion: "2",
+        });
+        await api.postWithToken("csrf", {
+            action: "edit",
+            title: wgPageName,
+            text: content.replace(/\{\{\s*(?:(?:Template|T|[模样樣]板):)?\s*(草稿|draft)\s*\}\}/gimu, ""),
+            summary: "移除{{[[T:Draft|Draft]]}}模板",
+            minor: true,
+            tags: "Automation tool",
+            watchlist: "nochange",
+        });
+    };
+
+    const publish = async () => {
+        try {
+            const moveRes = await api.postWithToken("csrf", {
+                action: "move",
+                from: wgPageName,
+                to: wgTitle,
+                movesubpages: true,
+                reason: "发布草稿",
+                noredirect: true,
+                watchlist: "nochange",
+                tags: "Automation tool",
+            });
+            if (Reflect.has(moveRes, "error")) {
+                throw moveRes;
+            }
+        } catch (e) {
+            if (e !== "moderation-move-queued") {
+                throw e;
+            }
+        }
+    };
+
+    $(mw.util.addPortletLink(
+        "p-cactions",
+        "#",
+        wgULS("发布草稿", "發佈草稿"),
+        "ca-lr-publish-draft",
+        wgULS("将草稿发布到主命名空间", "將草稿發佈到主命名空間"),
+    )).on("click", async (e) => {
+        e.preventDefault();
+        try {
+            const confirmed = await OO.ui.confirm(
+                wgULS("确认要将此草稿发布到主命名空间吗？", "確認要將此草稿發佈到主命名空間嗎？"),
+                { size: "medium" },
+            );
+            if (!confirmed) {
+                return;
+            }
+            await removeTemplate();
+            await publish();
+            mw.notify(wgULS("即将刷新……", "即將刷新……"), {
+                title: wgULS("发布成功", "發佈成功"),
+                type: "success",
+                tag: "lr-publish-draft",
+            });
+            setTimeout(() => location.reload(), 730);
+        } catch (e) {
+            console.error("[PublishDraft] Error:", e);
+            OO.ui.alert(String(e?.message ?? e ?? ""), {
+                title: wgULS("发布草稿出错", "發佈草稿出錯"),
+            });
+        }
+    });
+});

--- a/src/gadgets/publishDraft/Gadget-publishDraft.js
+++ b/src/gadgets/publishDraft/Gadget-publishDraft.js
@@ -45,7 +45,6 @@ $(() => {
                 action: "move",
                 from: wgPageName,
                 to: wgTitle,
-                movesubpages: true,
                 reason: "发布草稿",
                 noredirect: true,
                 watchlist: "nochange",

--- a/src/gadgets/publishDraft/Gadget-publishDraft.js
+++ b/src/gadgets/publishDraft/Gadget-publishDraft.js
@@ -1,47 +1,18 @@
 "use strict";
 $(() => {
-    const { wgNamespaceNumber, wgArticleId, wgPageName, wgTitle } = mw.config.get([
-        "wgNamespaceNumber",
+    const { wgArticleId, wgPageName, wgTitle } = mw.config.get([
         "wgArticleId",
         "wgPageName",
         "wgTitle",
     ]);
 
-    if (wgNamespaceNumber !== 118 || wgArticleId === 0) {
+    if (wgArticleId === 0) {
         return;
     }
-    const api = new mw.Api();
-
-    const removeTemplate = async () => {
-        const {
-            query: {
-                pages: [
-                    {
-                        revisions: [{ content }],
-                    },
-                ],
-            },
-        } = await api.post({
-            action: "query",
-            prop: "revisions",
-            rvprop: "content",
-            titles: wgPageName,
-            formatversion: "2",
-        });
-        await api.postWithToken("csrf", {
-            action: "edit",
-            title: wgPageName,
-            text: content.replace(/\{\{\s*(?:(?:Template|T|[模样樣]板):)?\s*(草稿|draft)\s*\}\}/gimu, ""),
-            summary: "移除{{[[T:Draft|Draft]]}}模板",
-            minor: true,
-            tags: "Automation tool",
-            watchlist: "nochange",
-        });
-    };
 
     const publish = async () => {
         try {
-            const moveRes = await api.postWithToken("csrf", {
+            const moveRes = await new mw.Api().postWithToken("csrf", {
                 action: "move",
                 from: wgPageName,
                 to: wgTitle,
@@ -65,18 +36,17 @@ $(() => {
         "#",
         wgULS("发布草稿", "發佈草稿"),
         "ca-lr-publish-draft",
-        wgULS("将草稿发布到主命名空间", "將草稿發佈到主命名空間"),
+        wgULS("发布草稿", "發佈草稿"),
     )).on("click", async (e) => {
         e.preventDefault();
         try {
             const confirmed = await OO.ui.confirm(
-                wgULS("确认要将此草稿发布到主命名空间吗？", "確認要將此草稿發佈到主命名空間嗎？"),
+                wgULS(`确认要将此草稿发布到${wgTitle}吗？`, `確認要將此草稿發佈到${wgTitle}嗎？`),
                 { size: "medium" },
             );
             if (!confirmed) {
                 return;
             }
-            await removeTemplate();
             await publish();
             mw.notify(wgULS("即将刷新……", "即將刷新……"), {
                 title: wgULS("发布成功", "發佈成功"),

--- a/src/gadgets/publishDraft/definition.yaml
+++ b/src/gadgets/publishDraft/definition.yaml
@@ -29,6 +29,7 @@ rights:
 peers: []
 
 dependencies:
+  - mediawiki.api
   - ext.gadget.site-lib
 
 _sites:

--- a/src/gadgets/publishDraft/definition.yaml
+++ b/src/gadgets/publishDraft/definition.yaml
@@ -30,6 +30,7 @@ peers: []
 
 dependencies:
   - mediawiki.api
+  - oojs-ui
   - ext.gadget.site-lib
 
 _sites:

--- a/src/gadgets/publishDraft/definition.yaml
+++ b/src/gadgets/publishDraft/definition.yaml
@@ -1,0 +1,40 @@
+ResourceLoader: true
+
+hidden: false
+
+default: true
+
+supportsUrlLoad: false
+
+skins: []
+
+actions:
+  - view
+
+categories: []
+
+namespaces:
+  - 118
+
+contentModels: []
+
+type: general
+
+package: false
+
+rights:
+  - edit
+  - move
+
+peers: []
+
+dependencies:
+  - ext.gadget.site-lib
+
+_sites:
+  - zh
+
+_section: editing
+
+_files:
+  - Gadget-publishDraft.js


### PR DESCRIPTION
不知道还需要什么功能，先这样吧

## 由 Sourcery 提供的摘要

新功能：
- 引入一个 `publishDraft` 小工具，为界面添加一个操作，用于将草稿页面移动到主命名空间，并在发布前移除草稿模板。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Introduce a publishDraft gadget that adds a UI action to move draft pages to the main namespace and removes the draft template before publishing.

</details>