### PR TITLE
refactor(Gadget/MarkAsResolved-restricted): don't change watchlist status when goodeditors are using MarkAsResolved gadget

### DIFF
--- a/src/gadgets/MarkAsResolved-restricted/Gadget-MarkAsResolved-restricted.js
+++ b/src/gadgets/MarkAsResolved-restricted/Gadget-MarkAsResolved-restricted.js
@@ -218,6 +218,7 @@ $(() => {
                 summary: `标记讨论串「/* ${this.sectionTitle} */」状态为【${this.statusLabel}】`,
                 tags: "Automation tool",
                 nocreate: true,
+                watchlist: "nochange",
                 appendtext: `${this.precomment.length > 0 ? `\n:${this.precomment}——~~~~` : ""}\n\n{{MarkAsResolved|time={{subst:#timel:Ymd}}|status=${this.status}|archive-offset=${this.archiveOffset}|comment=${this.comment}|sign=~~~~}}`,
             });
             if (d.error) {


### PR DESCRIPTION
在 `Gadget-MarkAsResolved-restricted.js` 的 API 请求选项中添加了 `watchlist: "nochange"`，以防止优质编辑者使用时讨论版监视状态发生变化

## Summary by Sourcery

Bug Fixes:
- 确保来自受 MarkAsResolved 限制的小工具的 API 请求不会更改监视列表状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure API requests from the MarkAsResolved-restricted gadget leave the watchlist status unchanged.

</details>