### PR TITLE
fix(Gadget/displayname-show): 不应在用户名被移除时显示

### DIFF
--- a/src/gadgets/displayname-show/Gadget-displayname-show.js
+++ b/src/gadgets/displayname-show/Gadget-displayname-show.js
@@ -88,6 +88,10 @@ $(() => {
     const userLinks = document.querySelectorAll(".mw-userlink");
 
     for (const userLink of userLinks) {
+        if (userLink.classList.contains("history-deleted")) {
+            continue;
+        }
+
         let { userName = userLink.textContent } = userLink.dataset;
         const { userNick = "" } = userLink.dataset;
         if (userNick === "已注销#0000" && !wgUserGroups.includes("suppress")) {


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 防止在页面历史记录中，将标记为已删除用户名的用户链接显示为显示名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent display names from being shown for user links marked as deleted usernames in page history.

</details>