### PR TITLE
feat: 隐藏链入页面的用户徽章

### DIFF
--- a/src/gadgets/site-styles/Gadget-site-styles.css
+++ b/src/gadgets/site-styles/Gadget-site-styles.css
@@ -1499,6 +1499,8 @@ body.mw-special-Log .mw-htmlform-flatlist > .oo-ui-fieldLayout:nth-child(4) {
 .mw-prefixindex-list moe-badge,
 .mw-allpages-body moe-badges,
 .mw-allpages-body moe-badge,
+#mw-whatlinkshere-list moe-badges,
+#mw-whatlinkshere-list moe-badge,
 #mw-content-subtitle moe-badges {
     display: none;
 }


### PR DESCRIPTION
## Summary by Sourcery

新功能：
- 将隐藏徽章的样式扩展到“链入页面”（What links here）页面，使用户徽章不再出现在其链接列表中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Extend badge-hiding styles to the "What links here" page so user badges no longer appear in its link list.

</details>