### PR TITLE
feat(Gadget/report): enhance feedback submission flow

### DIFF
--- a/src/gadgets/report/Gadget-report.js
+++ b/src/gadgets/report/Gadget-report.js
@@ -233,8 +233,10 @@ $(() => {
             this.secondaryTypeSelector.connect(this, { change: "continueOK" });
             this.reasonTextarea.connect(this, { change: "continueOK" });
             this.emailInput.connect(this, { change: "continueOK" });
+            this.suggestToTalkBoardInput.connect(this, { change: "updateEmailRequirement" });
 
             this.$body.append(this.stackLayout.$element);
+            this.updateEmailRequirement();
         }
         openSecondary(value) {
             const config = MGPReportDialog.types[value];
@@ -263,9 +265,16 @@ $(() => {
             } else {
                 this.suggestToTalkBoardInputField.$element.slideUp("fast", () => this.updateSize());
             }
+            this.updateEmailRequirement();
         }
         continueOK() {
             this.actions.setAbilities({ "continue": true });
+        }
+        updateEmailRequirement() {
+            const config = MGPReportDialog.types[this.primaryTypeSelector.getValue()];
+            const postingToTalkBoard = userIsAutoconfirmed && config?.suggestToTalkBoard && this.suggestToTalkBoardInput.isSelected();
+            this.emailInput.setRequired(!postingToTalkBoard);
+            this.emailInput.setIndicator(postingToTalkBoard ? null : "required");
         }
         async validateFeedback() {
             this.primaryType = this.primaryTypeSelector.getValue();
@@ -335,10 +344,10 @@ $(() => {
                         if (this.secondaryType !== "none") {
                             details.push(`次要${wgULS("问题", "問題")}：${this.secondaryType}`);
                         }
-                        details.push(
-                            `${wgULS("电子邮件", "電子郵件")}：${this.email}`,
-                            `您的理由：${this.reason}`,
-                        );
+                        if (!(userIsAutoconfirmed && MGPReportDialog.types[this.primaryType].suggestToTalkBoard && this.suggestToTalkBoardInput.isSelected())) {
+                            details.push(`${wgULS("电子邮件", "電子郵件")}：${this.email}`);
+                        }
+                        details.push(`您的理由：${this.reason}`);
                         if (userIsAutoconfirmed && MGPReportDialog.types[this.primaryType].suggestToTalkBoard) {
                             details.push(`${wgULS("是否提交到提问求助区", "是否提交到提問求助區")}：${this.suggestToTalkBoardInput.isSelected() ? "是" : "否"}`);
                         }
@@ -376,27 +385,21 @@ $(() => {
         async postMessageToBackend() {
             if (userIsAutoconfirmed && MGPReportDialog.types[this.primaryType].suggestToTalkBoard && this.suggestToTalkBoardInput.isSelected()) {
                 const sectiontitle = `【页面反馈】${this.primaryType}${this.secondaryType !== "none" ? ` - ${this.secondaryType}` : ""} @ ${this.wgPageName}`;
-                await api.postWithToken("csrf", {
-                    action: "edit",
-                    assertuser: mw.config.get("wgUserName"),
-                    title: "萌娘百科_talk:讨论版/提问求助",
-                    section: "new",
+                const response = await api.postWithToken("csrf", {
+                    action: "discussiontoolsedit",
+                    paction: "addtopic",
+                    page: "萌娘百科_talk:讨论版/提问求助",
                     sectiontitle,
-                    text: `<dl>\n<dt>页面信息：</dt>\n<dd><table class="wikitable" style="word-break: break-all;">\n<tr><td>primaryType</td><td>${this.primaryType}${this.secondaryType !== "none" ? `</td></tr>\n<tr><td>secondaryType</td><td>${this.secondaryType}` : ""}</td></tr>\n<tr><td>reportURL</td><td>${window.location.href}</td></tr>\n<tr><td>wgPageName</td><td>${this.wgPageName}<hr>[[${this.wgPageName}]]</td></tr>\n<tr><td>wgArticleId</td><td>${this.wgArticleId}</td></tr>\n<tr><td>wgCurRevisionId</td><td>${this.wgCurRevisionId}</td></tr>\n<tr><td>wgRevisionId</td><td>${this.wgRevisionId}</td></tr>\n</table></dd>\n<dt>用户反馈内容：</dt>\n<dd>${this.reason}——~~~~</dd>\n</dl>`,
+                    wikitext: `<dl>\n<dt>页面信息：</dt>\n<dd><table class="wikitable" style="word-break: break-all;">\n<tr><td>primaryType</td><td>${this.primaryType}${this.secondaryType !== "none" ? `</td></tr>\n<tr><td>secondaryType</td><td>${this.secondaryType}` : ""}</td></tr>\n<tr><td>reportURL</td><td>${window.location.href}</td></tr>\n<tr><td>wgPageName</td><td>${this.wgPageName}<hr>[[${this.wgPageName}]]</td></tr>\n<tr><td>wgArticleId</td><td>${this.wgArticleId}</td></tr>\n<tr><td>wgCurRevisionId</td><td>${this.wgCurRevisionId}</td></tr>\n<tr><td>wgRevisionId</td><td>${this.wgRevisionId}</td></tr>\n</table></dd>\n<dt>用户反馈内容：</dt>\n<dd>${this.reason}——~~~~</dd>\n</dl>`,
+                    autosubscribe: "yes",
                     tags: "Automation tool",
-                    watchlist: "watch",
+                    watchlist: "nochange",
+                    nocontent: "true",
                 });
-                const goToTalkBoardInput = new OO.ui.CheckboxInputWidget({
-                    selected: true,
-                });
-                const goToTalkBoardInputField = new OO.ui.FieldLayout(goToTalkBoardInput, {
-                    label: wgULS("到提问求助区查看该反馈", "到提問求助區檢視該反饋"),
-                    align: "inline",
-                });
+                const commentAnchor = $("<div>").html(response.discussiontoolsedit.contentSub).find('a[href^="#c-"]').last().attr("href");
                 const confirmBody = $("<div>").text(wgULS("您的反馈已提交到提问求助区，是否前往查看？", "您的反饋已提交到提問求助區，是否前往檢視？"));
-                confirmBody.append("<br>").append(goToTalkBoardInputField.$element);
                 if (await oouiDialog.confirm(confirmBody, oouiDialogConfig)) {
-                    window.open("/%E8%90%8C%E5%A8%98%E7%99%BE%E7%A7%91_talk:%E8%AE%A8%E8%AE%BA%E7%89%88/%E6%8F%90%E9%97%AE%E6%B1%82%E5%8A%A9#footer", "_blank");
+                    window.open(`${mw.util.getUrl("萌娘百科_talk:讨论版/提问求助")}${commentAnchor}`, "_blank");
                 }
                 return;
             }

--- a/src/gadgets/report/Gadget-report.js
+++ b/src/gadgets/report/Gadget-report.js
@@ -204,6 +204,11 @@ $(() => {
             });
 
             this.reasonTextarea.$element.find(".oo-ui-labelElement-label").css("pointer-events", "none");
+            this.reasonTextarea.$element.find(".oo-ui-labelElement-label").css("padding-top", "5px");
+            this.reasonTextarea.$element.find(".oo-ui-labelElement-label").css({
+                lineHeight: "20px",
+                height: "40px",
+            });
             this.secondaryTypeSelectorField.$element.hide();
             this.suggestToTalkBoardInputField.$element.hide();
 
@@ -428,6 +433,7 @@ $(() => {
     const reportDialog = new MGPReportDialog({
         size: "large",
     });
+    reportDialog.$element.css("z-index", "auto");
     windowManager.addWindows([reportDialog]);
     const initReport = async () => {
         if (wgNamespaceNumber > 0 && !await oouiDialog.confirm(`${wgULS("本页面<b>并非条目页面</b>，并不直接介绍事物，而仅为萌娘百科", "本頁面<b>並非條目頁面</b>，並不直接介紹事物，而僅為萌娘百科")}${wgULS("用户", "使用者", null, null, "用戶")}${wgULS("为方便编辑、交流沟通等使用。<br>您确定您仍要反馈本页面吗？", "為方便編輯、交流溝通等使用。<br>您確定您仍要反饋本頁面嗎？")}`, oouiDialogConfig)) {

--- a/src/gadgets/report/Gadget-report.js
+++ b/src/gadgets/report/Gadget-report.js
@@ -396,7 +396,7 @@ $(() => {
                     watchlist: "nochange",
                     nocontent: "true",
                 });
-                const commentAnchor = $("<div>").html(response.discussiontoolsedit.contentSub).find('a[href^="#c-"]').last().attr("href");
+                const commentAnchor = $("<div>").html(response.discussiontoolsedit.contentSub).find('a[href^="#c-"]').last().attr("href") || "";
                 const confirmBody = $("<div>").text(wgULS("您的反馈已提交到提问求助区，是否前往查看？", "您的反饋已提交到提問求助區，是否前往檢視？"));
                 if (await oouiDialog.confirm(confirmBody, oouiDialogConfig)) {
                     window.open(`${mw.util.getUrl("萌娘百科_talk:讨论版/提问求助")}${commentAnchor}`, "_blank");


### PR DESCRIPTION
## Sourcery 摘要

通过在讨论区报告中允许不填写电子邮件地址，并将用户直接链接到已创建的主题，改进反馈提交流程。

新功能：
- 允许符合条件的用户直接向帮助讨论区提交反馈，而无需提供电子邮件地址。
- 当用户选择查看已提交的反馈时，打开刚刚创建的确切讨论主题。

增强功能：
- 根据反馈是否提交到讨论区，动态更新电子邮件地址要求。
- 改进反馈对话框的标签布局，并在报告类别发生变化时重置讨论区提交状态。
- 改进理由栏位提示文字的样式。
- 改进对话框Z轴，避免Vector-2022下出现错误的顺序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve feedback submission by making email optional for discussion-board reports and linking users directly to the created topic.

New Features:
- Allow eligible users to submit feedback directly to the help discussion board without providing an email address.
- Open the exact newly created discussion topic when users choose to review their submitted feedback.

Enhancements:
- Dynamically update email requirements based on whether feedback is submitted to the discussion board.
- Improve feedback dialog label layout and reset discussion-board submission state when report categories change.

</details>

## Sourcery 摘要

通过将电子邮件设为可选项，并在用户提交后直接跳转到其已提交的主题，改进讨论板举报的反馈提交流程。

新功能：
- 允许符合条件的讨论板反馈提交无需提供电子邮件地址。
- 提交后将用户直接链接到新创建的讨论主题。

改进：
- 动态更新电子邮件要求，并在反馈提交到讨论板时省略电子邮件详细信息。
- 改进反馈对话框的字段布局，在举报类型更改时重置讨论提交行为，并修正对话框层叠顺序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the feedback submission flow for discussion-board reports by making email optional and taking users directly to their submitted topic.

New Features:
- Allow eligible discussion-board feedback submissions without requiring an email address.
- Link users directly to the newly created discussion topic after submission.

Enhancements:
- Dynamically update email requirements and omit email details when feedback is submitted to the discussion board.
- Improve feedback dialog field layout, reset discussion submission behavior when report types change, and correct dialog stacking.

</details>