### PR TITLE
fix(Gadget/deletion): 修复批量删除工具的锁状态与分类内文件删除缺陷

### DIFF
--- a/src/gadgets/deletion/Gadget-deletion.js
+++ b/src/gadgets/deletion/Gadget-deletion.js
@@ -8,6 +8,11 @@ $(() => (async () => {
 
     const deduplicate = (iterable) => [...new Set(iterable).values()];
     const generatePageLinkSelector = (title) => deduplicate([encodeURI(title), mw.util.wikiUrlencode(title)]).map((selector) => `a[href$="/${selector}"]`).join(",");
+    // e.stack 可能缺失或只有一行（此时取第二行会抛错），须做防御
+    const describeError = (e) => {
+        const detail = e instanceof Error && typeof e.stack === "string" ? (e.stack.split("\n")[1] || "").trim() : "";
+        return detail ? `${e} ${detail}` : e instanceof Error ? String(e) : JSON.stringify(e);
+    };
 
     let globalDeletionLock = false;
     const DELCATS = {
@@ -25,12 +30,24 @@ $(() => (async () => {
         if (!globalDeletionLock) {
             return;
         }
-        const $self = $(e.target).closest("a");
-        // Skip the batch deletion button and other in-page anchors, otherwise clicking them while locked opens a new page
-        if ($self.attr("href") === "#" || $self.closest("#ca-batdel").length) {
+        // Delegated handler: e.currentTarget is the matched <a>, more reliable than closest() from e.target
+        const $self = $(e.currentTarget);
+        const href = $self.attr("href");
+        if (!href) {
             return;
         }
-        window.open($self.prop("href"), "_blank");
+        // Skip the batch deletion button and same-page anchors (href="#...", or any URL resolving
+        // to the current page modulo the fragment, e.g. "javascript:"-free relative links);
+        // otherwise clicking them while locked opens a new page. Same-page check as suggested
+        // by gui-ying233 in #1027
+        const target = new URL(href, location.href);
+        target.hash = "";
+        const current = new URL(location.href);
+        current.hash = "";
+        if (target.href === current.href || $self.closest("#ca-batdel").length) {
+            return;
+        }
+        window.open(target.href, "_blank");
         return false;
     });
 
@@ -264,6 +281,7 @@ $(() => (async () => {
                         const url = new URL(self.prop("href"), location.origin);
                         const target = decodeURIComponent(url.searchParams.has("title") ? url.searchParams.get("title") : url.pathname.replace(/^\//, "")).replace(/_/g, " ");
                         let isDeleted = deletionResults.get(target);
+                        const fromCache = isDeleted !== undefined;
                         if (isDeleted === undefined) {
                             const page = pages.filter(({ title }) => title === target)[0];
                             try {
@@ -279,20 +297,23 @@ $(() => (async () => {
                                 });
                                 isDeleted = true;
                             } catch (e) {
-                                self.after(`<span class="batdel-result batdel-error"> ${wgULS("删除失败", "刪除失敗")}：${e instanceof Error ? `${e} ${e.stack.split("\n")[1].trim()}` : JSON.stringify(e)}</span>`);
+                                self.after(`<span class="batdel-result batdel-error"> ${wgULS("删除失败", "刪除失敗")}：${describeError(e)}</span>`);
                                 isDeleted = false;
                             }
                             deletionResults.set(target, isDeleted);
                         }
                         if (isDeleted) {
                             self.css("text-decoration", "line-through").after(`<span class="batdel-result batdel-success">${wgULS("删除成功", "刪除成功")}</span>`);
+                        } else if (fromCache) {
+                            // 详细错误已在首个链接旁展示，重复链接仅补充简短失败标记
+                            self.after(`<span class="batdel-result batdel-error"> ${wgULS("删除失败", "刪除失敗")}（${wgULS("同上", "同上")}）</span>`);
                         }
                     }
                     $spinner.remove();
                     $status.addClass("batdel-success").text(wgULS("删除已完成！", "刪除已完成！"));
                 } catch (e) {
                     $spinner.remove();
-                    $status.text(`${wgULS("发生错误", "發生錯誤")}：${e instanceof Error ? `${e} ${e.stack.split("\n")[1].trim()}` : JSON.stringify(e)}`);
+                    $status.text(`${wgULS("发生错误", "發生錯誤")}：${describeError(e)}`);
                 }
             } finally {
                 // eslint-disable-next-line require-atomic-updates

--- a/src/gadgets/deletion/Gadget-deletion.js
+++ b/src/gadgets/deletion/Gadget-deletion.js
@@ -21,7 +21,18 @@ $(() => (async () => {
     const wgPageName = mw.config.get("wgPageName");
     const wgUserName = mw.config.get("wgUserName");
     // Make sure that all links open in a new tab when locked
-    $("body").on("click", "a", (e) => globalDeletionLock ? window.open(e.target.href, "_blank") && false : null);
+    $("body").on("click", "a", (e) => {
+        if (!globalDeletionLock) {
+            return;
+        }
+        const $self = $(e.target).closest("a");
+        // Skip the batch deletion button and other in-page anchors, otherwise clicking them while locked opens a new page
+        if ($self.attr("href") === "#" || $self.closest("#ca-batdel").length) {
+            return;
+        }
+        window.open($self.prop("href"), "_blank");
+        return false;
+    });
 
     const api = new mw.Api();
     const $root = $(".mw-category-generated"), $items = $root.find("li");
@@ -151,7 +162,8 @@ $(() => (async () => {
     }
 
     // Deletion buttons
-    $portlet.on("click", () => {
+    $portlet.on("click", (e) => {
+        e.preventDefault();
         if ($("#batdel-control")[0] || globalDeletionLock) {
             return;
         }
@@ -231,47 +243,60 @@ $(() => (async () => {
 
             const $spinner = $('<img src="https://storage.moegirl.org.cn/moegirl/commons/d/d1/Windows_10_loading.gif" style="height: 1em; margin-top: -.25em;">'), $status = $("<span>");
 
-            $root.find(".batdel-result").remove();
-            $root.find(".batdel-select").prop("disabled", true);
-            $control.append("<br>", $spinner, $status);
-            $root.find("a:not(.batdel-bypass)").each((_, ele) => {
-                const self = $(ele);
-                if (!self.closest("li").find(".batdel-select:checked")[0]) {
-                    self.addClass("batdel-disabled");
-                }
-            });
             try {
-                $status.text(wgULS("正在删除，已完成删除的页面将会被删除线划去……", "正在刪除，已完成刪除的頁面將會被刪除線划去……"));
-                for (const ele of $root.find("a").not(".batdel-bypass, .batdel-disabled").toArray()) {
+                $root.find(".batdel-result").remove();
+                $root.find(".batdel-select").prop("disabled", true);
+                $control.append("<br>", $spinner, $status);
+                $root.find("a:not(.batdel-bypass)").each((_, ele) => {
                     const self = $(ele);
-                    if (!self.text().trim()) {
-                        return;
+                    if (!self.closest("li").find(".batdel-select:checked")[0]) {
+                        self.addClass("batdel-disabled");
                     }
-                    self.css("margin-right", "1em");
-                    const url = new URL(self.prop("href"), location.origin);
-                    const target = decodeURIComponent(url.searchParams.has("title") ? url.searchParams.get("title") : url.pathname.replace(/^\//, "")).replace(/_/g, " ");
-                    const page = pages.filter(({ title }) => title === target)[0];
-                    try {
-                        await api.postWithToken("csrf", {
-                            action: "delete",
-                            assertuser: wgUserName,
-                            format: "json",
-                            title: target,
-                            tags: "Automation tool",
-                            reason: `批量删除【${wgPageName}】下的页面${isDelCat && page.isTrusted && page.reason && page.user ? `（[[User_talk:${page.user}|${page.user}]]的挂删理由：${page.reason} ）` : deletionReason}`,
-                        }, {
-                            timeout: 99999,
-                        });
-                        self.css("text-decoration", "line-through").after(`<span class="batdel-result batdel-success">${wgULS("删除成功", "刪除成功")}</span>`);
-                    } catch (e) {
-                        self.after(`<span class="batdel-result batdel-error"> ${wgULS("删除失败", "刪除失敗")}：${e instanceof Error ? `${e} ${e.stack.split("\n")[1].trim()}` : JSON.stringify(e)}</span>`);
+                });
+                try {
+                    $status.text(wgULS("正在删除，已完成删除的页面将会被删除线划去……", "正在刪除，已完成刪除的頁面將會被刪除線划去……"));
+                    // Cache deletion results by target title, so that duplicated links pointing to the same page
+                    // (e.g. the thumbnail link and the caption link of one gallery item) won't be deleted twice
+                    const deletionResults = new Map();
+                    for (const ele of $root.find("a").not(".batdel-bypass, .batdel-disabled").toArray()) {
+                        const self = $(ele);
+                        self.css("margin-right", "1em");
+                        const url = new URL(self.prop("href"), location.origin);
+                        const target = decodeURIComponent(url.searchParams.has("title") ? url.searchParams.get("title") : url.pathname.replace(/^\//, "")).replace(/_/g, " ");
+                        let isDeleted = deletionResults.get(target);
+                        if (isDeleted === undefined) {
+                            const page = pages.filter(({ title }) => title === target)[0];
+                            try {
+                                await api.postWithToken("csrf", {
+                                    action: "delete",
+                                    assertuser: wgUserName,
+                                    format: "json",
+                                    title: target,
+                                    tags: "Automation tool",
+                                    reason: `批量删除【${wgPageName}】下的页面${isDelCat && page && page.isTrusted && page.reason && page.user ? `（[[User_talk:${page.user}|${page.user}]]的挂删理由：${page.reason} ）` : deletionReason}`,
+                                }, {
+                                    timeout: 99999,
+                                });
+                                isDeleted = true;
+                            } catch (e) {
+                                self.after(`<span class="batdel-result batdel-error"> ${wgULS("删除失败", "刪除失敗")}：${e instanceof Error ? `${e} ${e.stack.split("\n")[1].trim()}` : JSON.stringify(e)}</span>`);
+                                isDeleted = false;
+                            }
+                            deletionResults.set(target, isDeleted);
+                        }
+                        if (isDeleted) {
+                            self.css("text-decoration", "line-through").after(`<span class="batdel-result batdel-success">${wgULS("删除成功", "刪除成功")}</span>`);
+                        }
                     }
+                    $spinner.remove();
+                    $status.addClass("batdel-success").text(wgULS("删除已完成！", "刪除已完成！"));
+                } catch (e) {
+                    $spinner.remove();
+                    $status.text(`${wgULS("发生错误", "發生錯誤")}：${e instanceof Error ? `${e} ${e.stack.split("\n")[1].trim()}` : JSON.stringify(e)}`);
                 }
-                $spinner.remove();
-                $status.addClass("batdel-success").text(wgULS("删除已完成！", "刪除已完成！"));
-            } catch (e) {
-                $spinner.remove();
-                $status.text(`${wgULS("发生错误", "發生錯誤")}：${e instanceof Error ? `${e} ${e.stack.split("\n")[1].trim()}` : JSON.stringify(e)}`);
+            } finally {
+                // eslint-disable-next-line require-atomic-updates
+                globalDeletionLock = false;
             }
         });
 


### PR DESCRIPTION
Fix #148

## 问题与根因

### 问题 1：加载中 / 删除进行中 / 删除完成后再次点击「批量删除本分类下页面」按钮会打开新页面

根因有三处，均位于 `src/gadgets/deletion/Gadget-deletion.js`：

1. **锁未复位（主因）**：`runDeletion` 在删除开始时置 `globalDeletionLock = true`，但整个流程结束时从不复位。2022-09-02 的重构（`a24ae9f4`）把旧版的复位语句弄丢了，导致删除完成后锁永远为 true。
2. **全局委托误伤**：锁为 true 时，`body` 上的全局点击委托会把**任何** `<a>` 的点击转为 `window.open(href, "_blank")`——对 `href="#"` 的批量删除按钮（`#ca-batdel`）而言就是在新标签页打开当前分类页，即 issue 描述的现象。另外委托内使用 `e.target.href`，点击 `<a>` 内部的子元素（如 `<bdi>`、`<img>`）时取到的是子元素的 `href`（undefined），属于顺带修复。
3. **按钮 handler 无法阻止默认行为**：`.on("click", ...)` 不接收 `event`，早退分支（面板已存在或锁为 true）裸 `return`，不 `preventDefault`。

### 问题 2：不能批量删除分类下图片（分类页不含 `NOGALLERY` 魔术字时）

代码本身并不读取 `NOGALLERY`，根源是 MediaWiki 渲染差异：无 `NOGALLERY` 时文件以 gallery 缩略图（`<a>` 内只含 `<img>`）渲染，链接 `text()` 为空；而删除循环遇到空文字链接时执行的是 `return`——**中止整个删除队列**而非跳过该项。表象即「依赖 NOGALLERY」。

值得注意的是后端能力本来齐备：`gcmtype: "page|subcat|file"` 已查询文件，从 href 提取标题与对 File 标题的 `action=delete` 均可用，卡点纯在 DOM 遍历层。

## 修复内容

1. 按钮点击 handler 改为接收 `event` 并在最开始 `preventDefault()`，任何分支下都不再触发 `href="#"` 的默认跳转；
2. 全局锁点击委托：
   - 改用 `$(e.target).closest("a")` 取链接（修复子元素点击取不到 href）；
   - 跳过 `#ca-batdel` 与其他 `href="#"` 的页内锚点，不再打开新页面；
3. `runDeletion` 以 `try/finally` 包裹置锁后的全部流程，保证任何路径（含异常）下锁都会复位；
4. 删除循环：
   - 移除「空文字链接 `return` 中止全部」的逻辑，图片链接改由 href 提取的标题正常删除；
   - 以 `Map` 按目标标题缓存删除结果，避免同一 gallerybox 内缩略图链接与文字链接指向同一文件被重复请求删除（第二个链接直接复用结果标记删除线）；
   - 顺带加固：拼接删除理由时对 `page` 可能为 undefined 增加守卫（非挂删分类原本靠短路侥幸不报错）。

## 测试

- [x] `eslint`（0 error / 0 warning）与 `tsc --project tsconfig.production.json` 通过
- [ ] 站内回归（需 sysop 权限，请 review 时协助验证）：
  - 普通分类：勾选含图片的分类成员（无 NOGALLERY 的分类）批量删除，图片应被正常删除；同一文件的缩略图与文字链接只请求一次删除且均标记成功
  - 挂删分类（即将删除的页面）：理由加载期间点击批量删除按钮不应打开新页面
  - 删除完成后再次点击批量删除按钮不应打开新页面；取消按钮可正常收起面板
  - 删除进行中点击页面内普通链接应仍在新标签页打开（原保护行为保留）

## Sourcery 总结

修复批量删除锁定和项目处理逻辑，确保控件始终可用，并正确删除分类文件。

错误修复：
- 防止批量删除控件和页面内锚点在删除过程中打开意外的新页面。
- 在删除完成或发生错误后恢复删除锁定，并在删除过程中保留普通链接的“在新标签页中打开”行为。
- 支持批量删除以图库形式渲染的文件，并避免对指向同一页面的链接发送重复删除请求。

增强功能：
- 改进对缺失页面元数据时删除状态的处理，并始终阻止按钮的默认导航行为。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

修复批量删除锁定和项目处理逻辑，确保控件保持可用，并正确删除分类文件。

错误修复：
- 删除锁定期间，防止批量删除控件和同页锚点打开意外的新标签页。
- 在删除完成或发生错误后恢复删除锁定状态，并在删除期间保留普通链接打开新标签页的行为。
- 支持删除以图库缩略图形式呈现的文件，并避免对指向同一页面的链接发送重复删除请求。

增强功能：
- 改进删除错误报告，并在构建删除原因时安全处理缺失的页面元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix batch deletion locking and item processing so the controls remain usable and category files are deleted correctly.

Bug Fixes:
- Prevent batch-deletion controls and same-page anchors from opening unintended new tabs while deletion is locked.
- Restore the deletion lock after completion or errors and preserve new-tab behavior for ordinary links during deletion.
- Support deleting files rendered as gallery thumbnails and avoid duplicate deletion requests for links targeting the same page.

Enhancements:
- Improve deletion error reporting and safely handle missing page metadata when constructing deletion reasons.

</details>

</details>