### PR TITLE
fix(Gadget/ReferenceTooltips): 支持在 Moeskin 皮肤下从页脚重新启用

### DIFF
--- a/src/gadgets/ReferenceTooltips/Gadget-ReferenceTooltips.css
+++ b/src/gadgets/ReferenceTooltips/Gadget-ReferenceTooltips.css
@@ -220,3 +220,9 @@ html.skin-theme-clientpref-night .rt-settingsLink {
 .rt-fade-out-up {
 	animation: rt-fade-out-up 0.2s ease forwards;
 }
+
+/* Moeskin's footer is not a <ul>, so the enable item needs its own block styling */
+body.skin-moeskin .rt-enableItem {
+	display: block;
+	margin-top: 0.5em;
+}

--- a/src/gadgets/ReferenceTooltips/Gadget-ReferenceTooltips.js
+++ b/src/gadgets/ReferenceTooltips/Gadget-ReferenceTooltips.js
@@ -145,8 +145,14 @@
                 }
                 return;
             }
-            if (mw.config.get("skin") !== "moeskin" || moeskinFooterObserver) {
+            if (mw.config.get("skin") !== "moeskin") {
                 return;
+            }
+            // rt() 可能因 wikipage.content 钩子被多次调用：先断开旧观察器（其闭包绑定的
+            // 是过期内容），再以本次调用的新闭包重建，保证启用链接作用于当前内容
+            if (moeskinFooterObserver) {
+                moeskinFooterObserver.disconnect();
+                moeskinFooterObserver = undefined;
             }
             moeskinFooterObserver = new MutationObserver(() => {
                 if (!$("#moe-global-footer-top").length) {
@@ -154,6 +160,10 @@
                 }
                 moeskinFooterObserver.disconnect();
                 moeskinFooterObserver = undefined;
+                if (enabled) {
+                    // 等待页脚期间工具已在设置面板中被重新启用，无需页脚入口
+                    return;
+                }
                 addEnableLink();
             });
             moeskinFooterObserver.observe(document.body, { childList: true, subtree: true });

--- a/src/gadgets/ReferenceTooltips/Gadget-ReferenceTooltips.js
+++ b/src/gadgets/ReferenceTooltips/Gadget-ReferenceTooltips.js
@@ -71,6 +71,8 @@
         .addClass("rt-overlay")
         .appendTo($body);
     let windowManager;
+    // Guard against stacking multiple observers when rt() is called more than once
+    let moeskinFooterObserver;
     // Can't use before https://phabricator.wikimedia.org/T369880 is resolved
     // mw.loader.using( 'mediawiki.page.ready' ).then( function ( require ) {
     // $teleportTarget = $( require( 'mediawiki.page.ready' ).teleportTarget );
@@ -104,6 +106,14 @@
             $window.off(".rt");
         };
 
+        const makeEnableAnchor = () => $("<a>")
+            .text(mw.msg("rt-enable-footer"))
+            .attr("href", "#")
+            .click((e) => {
+                e.preventDefault();
+                enableRt();
+            });
+
         const addEnableLink = () => {
             // #footer-places – Vector
             // #f-list – Timeless, Monobook, Modern
@@ -112,21 +122,41 @@
             if (!$footer.length) {
                 $footer = $("#footer li").parent();
             }
-            if (!$footer.find(".rt-enableItem").length) {
-                $footer.append(
-                    $("<li>")
-                        .addClass("rt-enableItem")
-                        .append(
-                            $("<a>")
-                                .text(mw.msg("rt-enable-footer"))
-                                .attr("href", "#")
-                                .click((e) => {
-                                    e.preventDefault();
-                                    enableRt();
-                                }),
-                        ),
-                );
+            if ($footer.length) {
+                if (!$footer.find(".rt-enableItem").length) {
+                    $footer.append(
+                        $("<li>")
+                            .addClass("rt-enableItem")
+                            .append(makeEnableAnchor()),
+                    );
+                }
+                return;
             }
+            // #moe-global-footer-top – Moeskin, whose footer is rendered client-side (Vue)
+            // and therefore may not exist yet when this function runs
+            const $moeskinFooter = $("#moe-global-footer-top");
+            if ($moeskinFooter.length) {
+                if (!$moeskinFooter.find(".rt-enableItem").length) {
+                    $moeskinFooter.append(
+                        $("<span>")
+                            .addClass("rt-enableItem")
+                            .append(makeEnableAnchor()),
+                    );
+                }
+                return;
+            }
+            if (mw.config.get("skin") !== "moeskin" || moeskinFooterObserver) {
+                return;
+            }
+            moeskinFooterObserver = new MutationObserver(() => {
+                if (!$("#moe-global-footer-top").length) {
+                    return;
+                }
+                moeskinFooterObserver.disconnect();
+                moeskinFooterObserver = undefined;
+                addEnableLink();
+            });
+            moeskinFooterObserver.observe(document.body, { childList: true, subtree: true });
         };
 
         function TooltippedElement($element) {


### PR DESCRIPTION
Fix #870

## 问题与根因

在参数设置中启用参考文献提示工具后，若在其设置面板里取消启用，Moeskin 皮肤下无法通过页脚链接重新启用（Vector 正常），只能回参数设置重开。

根因在 `addEnableLink()`：页脚重启用链接只会追加到传统皮肤的页脚容器——`#footer-places`（Vector）、`#f-list`（Timeless/Monobook/Modern）、`#footer li` 的父级（Cologne Blue）。Moeskin 是自绘皮肤，页脚命名空间是 `#moe-global-footer*`，上述选择器全部落空，`append()` 成为空操作——链接根本没有被插入。禁用状态下该链接是唯一的图形化重启用入口，于是用户被锁死。

## 修复内容

1. **兼容 Moeskin 页脚**：在传统容器都找不到时，改为把启用链接追加到 Moeskin 的页脚容器 `#moe-global-footer-top`（容器 id 已从本仓库 `moeskin-classic` 小工具的样式与线上页面结构双重核实；页脚消息内容里的 `#footer-info-copyright` 等 id 属于可编辑的 wiki 消息内容，不作依赖）。
2. **处理客户端渲染时机**：Moeskin 的页脚由 Vue 在客户端渲染，gadget 执行时容器可能尚不存在。此时挂一个 `document.body` 上的 `MutationObserver`，等容器出现后再追加。观察器以外层变量做幂等保护，避免 `rt()` 因 `wikipage.content` 钩子等被多次调用时叠加多个观察器；一旦插入成功即断开。
3. **样式**：Moeskin 页脚不是 `<ul><li>` 结构，为其下的 `.rt-enableItem` 增加最小的块级样式（`Gadget-ReferenceTooltips.css`）。
4. 重构：抽出 `makeEnableAnchor()` 供两个分支复用，传统皮肤行为不变。

## 测试

- [x] `eslint` / `stylelint` / `tsc` 全部通过
- [ ] 站内回归（请 review 时协助验证）：
  - Moeskin：设置面板中取消启用后，页脚出现「启用参考文献提示工具」链接，点击后恢复正常工作
  - Vector：禁用后页脚链接行为与之前一致（回归确认）
  - Moeskin 下禁用后刷新页面，页脚链接依然存在

## Sourcery 摘要

支持用户在 Moeskin 和传统皮肤中通过页脚恢复 ReferenceTooltips。

新功能：
- 使用 Moeskin 皮肤时，支持从页脚重新启用 ReferenceTooltips。

错误修复：
- 修复 Moeskin 中因其客户端渲染的页脚导致重新启用链接缺失的问题。

改进：
- 保留传统皮肤现有的页脚行为，同时处理 Moeskin 页脚的渲染和样式。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

允许用户在 Moeskin 和传统皮肤中通过页脚恢复 ReferenceTooltips。

新功能：
- 使用 Moeskin 皮肤时，支持从页脚重新启用 ReferenceTooltips。

错误修复：
- 恢复 Moeskin 中缺失的页脚重新启用链接，包括在小工具加载后渲染页脚的情况。

增强功能：
- 在共享启用链接创建逻辑并添加 Moeskin 专属呈现方式的同时，保留传统皮肤现有的页脚行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable users to recover ReferenceTooltips through the footer across Moeskin and traditional skins.

New Features:
- Support re-enabling ReferenceTooltips from the footer when using the Moeskin skin.

Bug Fixes:
- Restore the missing footer re-enable link in Moeskin, including when its footer is rendered after the gadget loads.

Enhancements:
- Preserve existing footer behavior for traditional skins while sharing enable-link creation and adding Moeskin-specific presentation.

</details>

</details>