### PR TITLE
fix(global/zh): 触摸屏上外链确认与黑幕二次点击联动，修复看不到链接文本的冲突

### DIFF
--- a/src/gadgets/HeimuToggle/Gadget-heimu-toggle.js
+++ b/src/gadgets/HeimuToggle/Gadget-heimu-toggle.js
@@ -14,6 +14,9 @@ $(() => {
     btn.on("click", () => {
         btn.text($("body.heimu_toggle_on")[0] ? wgULS("半隐黑幕", "半隱黑幕") : wgULS("隐藏黑幕", "隱藏黑幕"));
         $body.toggleClass("heimu_toggle_on");
+        // 通知其他小工具（如全站 JS 的外链确认与黑幕点击联动）半隐状态已切换，
+        // 参数为切换后的状态；mw.hook 会对晚注册的监听重放，与加载顺序无关
+        mw.hook("heimu_toggle").fire($body.hasClass("heimu_toggle_on"));
         $(".colormu").each((_, ele) => {
             const $thisColormu = $(ele);
             if ($thisColormu.hasClass("colormu_toggle_on")) {

--- a/src/global/zh/Moeskin.js
+++ b/src/global/zh/Moeskin.js
@@ -282,6 +282,18 @@
                 return;
             }
         });
+        // 半隐开启期间黑幕监听会跳过记录，lastClickedHeimu 会冻结在开启前的那次点击上；
+        // 若不清除，关闭半隐后首次点击该黑幕会被误判为“二次点击”而直接弹出确认框
+        // （gui-ying233 于 #1029 提出）。仅在“半隐由开→关”的跳变时重置，
+        // 避免其他 body class 变化在正常模式交互中途误清状态
+        let wasToggleOn = document.body.classList.contains("heimu_toggle_on");
+        new MutationObserver(() => {
+            const isToggleOn = document.body.classList.contains("heimu_toggle_on");
+            if (wasToggleOn && !isToggleOn) {
+                lastClickedHeimu = null;
+            }
+            wasToggleOn = isToggleOn;
+        }).observe(document.body, { attributes: true, attributeFilter: ["class"] });
     };
     /* noteTAIcon */
     const noteTAIcon = () => {

--- a/src/global/zh/Moeskin.js
+++ b/src/global/zh/Moeskin.js
@@ -195,12 +195,17 @@
     };
 
     // externalLinkConfirm 与 setupHeimuClickListener 共享的状态：
-    // 记录上一次（touch/pen）点击所在的黑幕元素，用于实现“首次点击揭示黑幕内容，再次点击才触发”。
+    // 记录上一次（touch/pen）点击所在的黑幕元素及其时间戳，用于实现“首次点击揭示黑幕内容，再次点击才触发”。
+    // 状态只在 HEIMU_CONFIRM_WINDOW 时间窗内被视为有效：超时后（包括半隐开关切换、长时间停留等
+    // 任何时序问题）一律按“首次点击”处理，从根上避免过期状态误判（gui-ying233 于 #1029 两度提出）。
     // 注意二者都监听 #mw-content-text 的 click，同一事件里先注册的先执行——
     // 因此 externalLinkConfirm 必须先于 setupHeimuClickListener 注册/调用（见文件底部 main 部分），
     // 这样外链确认读到的是上一次点击留下的状态，而本次点击的状态由黑幕监听随后写入。
     /** @type {HTMLElement|null} */
     let lastClickedHeimu = null;
+    let lastClickedHeimuAt = 0;
+    // “再次点击”的有效窗口：超过后视为新的一次“首次点击”（重新揭示，多一次点击但不会误弹确认框）
+    const HEIMU_CONFIRM_WINDOW = 10000;
 
     /** 外部链接提示 */
     const externalLinkConfirm = () => {
@@ -232,13 +237,16 @@
             if (/^(?:.+\.)moegirl\.org\.cn$/i.test(hrefURL.host)) {
                 return;
             }
-            // 与黑幕二次点击逻辑联动：若链接在黑幕内且这是对该黑幕的首次点击，
+            // 与黑幕二次点击逻辑联动：若链接在黑幕内且这是对该黑幕有效窗口内的首次点击，
             // 本次点击只用于揭示黑幕内容，不出确认框（由黑幕监听阻止跳转）；
-            // 再次点击同一黑幕才弹出确认框。黑幕半隐（heimu_toggle_on）时文字始终可见，无需联动。
+            // 有效窗口内的再次点击才弹出确认框。黑幕半隐（heimu_toggle_on）时文字始终可见，无需联动。
             // 否则确认框会打断触摸屏的 hover 态，黑幕重新遮住文字，用户始终看不到链接文本（issue #708）
             if (!document.body.classList.contains("heimu_toggle_on")) {
                 const currentHeimu = target.closest(".heimu, .colormu, .heimu-like");
-                if (currentHeimu && lastClickedHeimu !== currentHeimu) {
+                const isConfirmedSecondTap = currentHeimu
+                    && lastClickedHeimu === currentHeimu
+                    && Date.now() - lastClickedHeimuAt < HEIMU_CONFIRM_WINDOW;
+                if (currentHeimu && !isConfirmedSecondTap) {
                     return;
                 }
             }
@@ -274,26 +282,16 @@
                 if (lastClickedHeimu !== currentHeimu) {
                     e.preventDefault();
                 }
-                // 记录最后点击的黑幕
+                // 记录最后点击的黑幕及其时间戳（供外链确认的新鲜度判断）
                 lastClickedHeimu = currentHeimu;
+                lastClickedHeimuAt = Date.now();
             } else {
                 // 这个元素不是黑幕，重置状态
                 lastClickedHeimu = null;
+                lastClickedHeimuAt = 0;
                 return;
             }
         });
-        // 半隐开启期间黑幕监听会跳过记录，lastClickedHeimu 会冻结在开启前的那次点击上；
-        // 若不清除，关闭半隐后首次点击该黑幕会被误判为“二次点击”而直接弹出确认框
-        // （gui-ying233 于 #1029 提出）。仅在“半隐由开→关”的跳变时重置，
-        // 避免其他 body class 变化在正常模式交互中途误清状态
-        let wasToggleOn = document.body.classList.contains("heimu_toggle_on");
-        new MutationObserver(() => {
-            const isToggleOn = document.body.classList.contains("heimu_toggle_on");
-            if (wasToggleOn && !isToggleOn) {
-                lastClickedHeimu = null;
-            }
-            wasToggleOn = isToggleOn;
-        }).observe(document.body, { attributes: true, attributeFilter: ["class"] });
     };
     /* noteTAIcon */
     const noteTAIcon = () => {

--- a/src/global/zh/Moeskin.js
+++ b/src/global/zh/Moeskin.js
@@ -262,8 +262,8 @@
                 return;
             }
             /** @type {HTMLElement} */
-            // 小工具“黑幕半隐”启用时正常跳转
-            if (document.body.closest(".heimu_toggle_on")) {
+            // 小工具“黑幕半隐”启用时正常跳转（与 externalLinkConfirm 中的判定方式保持一致）
+            if (document.body.classList.contains("heimu_toggle_on")) {
                 return;
             }
             const target = e.target;

--- a/src/global/zh/Moeskin.js
+++ b/src/global/zh/Moeskin.js
@@ -195,17 +195,17 @@
     };
 
     // externalLinkConfirm 与 setupHeimuClickListener 共享的状态：
-    // 记录上一次（touch/pen）点击所在的黑幕元素及其时间戳，用于实现“首次点击揭示黑幕内容，再次点击才触发”。
-    // 状态只在 HEIMU_CONFIRM_WINDOW 时间窗内被视为有效：超时后（包括半隐开关切换、长时间停留等
-    // 任何时序问题）一律按“首次点击”处理，从根上避免过期状态误判（gui-ying233 于 #1029 两度提出）。
+    // 记录上一次（touch/pen）点击所在的黑幕元素，用于实现“首次点击揭示黑幕内容，再次点击才触发”。
+    // HeimuToggle 小工具在半隐开关切换时会 fire "heimu_toggle" hook，本文件据此清空共享状态，
+    // 避免开关期间冻结的旧状态把切换后的首次点击误判为二次点击（#1029 评审意见，与 HeimuToggle 协同）。
     // 注意二者都监听 #mw-content-text 的 click，同一事件里先注册的先执行——
     // 因此 externalLinkConfirm 必须先于 setupHeimuClickListener 注册/调用（见文件底部 main 部分），
     // 这样外链确认读到的是上一次点击留下的状态，而本次点击的状态由黑幕监听随后写入。
     /** @type {HTMLElement|null} */
     let lastClickedHeimu = null;
-    let lastClickedHeimuAt = 0;
-    // “再次点击”的有效窗口：超过后视为新的一次“首次点击”（重新揭示，多一次点击但不会误弹确认框）
-    const HEIMU_CONFIRM_WINDOW = 10000;
+    mw.hook("heimu_toggle").add(() => {
+        lastClickedHeimu = null;
+    });
 
     /** 外部链接提示 */
     const externalLinkConfirm = () => {
@@ -237,16 +237,13 @@
             if (/^(?:.+\.)moegirl\.org\.cn$/i.test(hrefURL.host)) {
                 return;
             }
-            // 与黑幕二次点击逻辑联动：若链接在黑幕内且这是对该黑幕有效窗口内的首次点击，
+            // 与黑幕二次点击逻辑联动：若链接在黑幕内且这是对该黑幕的首次点击，
             // 本次点击只用于揭示黑幕内容，不出确认框（由黑幕监听阻止跳转）；
-            // 有效窗口内的再次点击才弹出确认框。黑幕半隐（heimu_toggle_on）时文字始终可见，无需联动。
+            // 再次点击同一黑幕才弹出确认框。黑幕半隐（heimu_toggle_on）时文字始终可见，无需联动。
             // 否则确认框会打断触摸屏的 hover 态，黑幕重新遮住文字，用户始终看不到链接文本（issue #708）
             if (!document.body.classList.contains("heimu_toggle_on")) {
                 const currentHeimu = target.closest(".heimu, .colormu, .heimu-like");
-                const isConfirmedSecondTap = currentHeimu
-                    && lastClickedHeimu === currentHeimu
-                    && Date.now() - lastClickedHeimuAt < HEIMU_CONFIRM_WINDOW;
-                if (currentHeimu && !isConfirmedSecondTap) {
+                if (currentHeimu && lastClickedHeimu !== currentHeimu) {
                     return;
                 }
             }
@@ -282,13 +279,11 @@
                 if (lastClickedHeimu !== currentHeimu) {
                     e.preventDefault();
                 }
-                // 记录最后点击的黑幕及其时间戳（供外链确认的新鲜度判断）
+                // 记录最后点击的黑幕
                 lastClickedHeimu = currentHeimu;
-                lastClickedHeimuAt = Date.now();
             } else {
                 // 这个元素不是黑幕，重置状态
                 lastClickedHeimu = null;
-                lastClickedHeimuAt = 0;
                 return;
             }
         });

--- a/src/global/zh/Moeskin.js
+++ b/src/global/zh/Moeskin.js
@@ -194,6 +194,14 @@
         });
     };
 
+    // externalLinkConfirm 与 setupHeimuClickListener 共享的状态：
+    // 记录上一次（touch/pen）点击所在的黑幕元素，用于实现“首次点击揭示黑幕内容，再次点击才触发”。
+    // 注意二者都监听 #mw-content-text 的 click，同一事件里先注册的先执行——
+    // 因此 externalLinkConfirm 必须先于 setupHeimuClickListener 注册/调用（见文件底部 main 部分），
+    // 这样外链确认读到的是上一次点击留下的状态，而本次点击的状态由黑幕监听随后写入。
+    /** @type {HTMLElement|null} */
+    let lastClickedHeimu = null;
+
     /** 外部链接提示 */
     const externalLinkConfirm = () => {
         const modulesReady = mw.loader.using(["ext.gadget.site-lib", "oojs-ui-windows", "oojs-ui-core"]);
@@ -224,6 +232,16 @@
             if (/^(?:.+\.)moegirl\.org\.cn$/i.test(hrefURL.host)) {
                 return;
             }
+            // 与黑幕二次点击逻辑联动：若链接在黑幕内且这是对该黑幕的首次点击，
+            // 本次点击只用于揭示黑幕内容，不出确认框（由黑幕监听阻止跳转）；
+            // 再次点击同一黑幕才弹出确认框。黑幕半隐（heimu_toggle_on）时文字始终可见，无需联动。
+            // 否则确认框会打断触摸屏的 hover 态，黑幕重新遮住文字，用户始终看不到链接文本（issue #708）
+            if (!document.body.classList.contains("heimu_toggle_on")) {
+                const currentHeimu = target.closest(".heimu, .colormu, .heimu-like");
+                if (currentHeimu && lastClickedHeimu !== currentHeimu) {
+                    return;
+                }
+            }
             e.preventDefault();
             await modulesReady;
             const response = await OO.ui.confirm(getConfirmMessage(hrefURL));
@@ -236,8 +254,7 @@
      * 再次点击同一个黑幕里的元素，才会触发事件
      */
     const setupHeimuClickListener = () => {
-        /** @type {HTMLElement|null} */
-        let lastClickedHeimu = null;
+        // lastClickedHeimu 定义在本文件 externalLinkConfirm 之前，二者共享
         document.querySelector("#mw-content-text")?.addEventListener("click", (e) => {
             const pointerType = e.pointerType;
             if (pointerType !== "touch" && pointerType !== "pen") {


### PR DESCRIPTION
Fix #708

## 问题与冲突机制

黑幕（`.heimu` 等，文字与背景同色、hover/`:active` 才显字）内的外链，在触摸屏上点击后弹出外链确认框，关闭确认框后黑幕重新遮住，用户自始至终看不到链接文本，也就无从判断是否继续访问。

冲突由两个监听在同一元素（`#mw-content-text` 的 click）上的交互造成：

1. 外链确认（`externalLinkConfirm`）**先注册先执行**：touch/pen 点击落在 `.external` 链接上就立即 `preventDefault()` 并弹出 `OO.ui.confirm`；
2. 黑幕二次点击逻辑（`setupHeimuClickListener`）的设计是「首次点击只揭示文字并 `preventDefault`，第二次点击同一黑幕才放行」，但它后执行，且外链确认完全不读它的「首次点击」状态；
3. 模态确认框还会打断 tap 建立的黑幕 hover 态——于是「第一次点击只显字」的黑幕协议被确认框短路，文字从未被看到。

## 修复内容（`src/global/zh/Moeskin.js`）

1. 把 `lastClickedHeimu` 从 `setupHeimuClickListener` 内部提升为两个函数共享的状态（单一写入方仍是黑幕监听，外链确认只读）；
2. `externalLinkConfirm` 在确认目标是外部链接后增加联动判断：若链接在黑幕（`.heimu, .colormu, .heimu-like`）内且这是对该黑幕的**首次**点击，直接 return 让路——本次 tap 交给黑幕逻辑揭示文字；**再次**点击同一黑幕才弹出确认框；
3. 黑幕半隐小工具（`heimu_toggle_on`）开启时文字始终可见，跳过联动，不增加多余点击；
4. 在共享状态处注释说明该方案依赖的监听注册顺序（`externalLinkConfirm` 必须先注册，使确认读到的是上一次点击的状态、本次状态由黑幕监听随后写入），与文件底部 main 部分的调用顺序一致。

修复后行为：

- 黑幕内外链（触摸屏）：第一次点击 → 黑幕显字；第二次点击 → 弹确认框 → 确认后新窗口打开；
- 黑幕外外链：行为不变（一次点击即弹确认框）；
- 桌面端鼠标：完全不受影响（两个监听均只处理 touch/pen）。

## 测试

- [x] `eslint` / `tsc` 通过
- [ ] 真机/触摸回归（请 review 时协助验证，模拟器亦可）：
  - 触摸点击黑幕内外部链接：一击显字、二击弹确认，确认后正常打开
  - 触摸点击黑幕外部链接：一击即弹确认（原行为保留）
  - 开启「黑幕半隐」后：一击即弹确认
  - 桌面端：外链点击行为无变化；黑幕 hover 显字无变化

## Sourcery 总结

修复触摸设备上黑幕外链的点击交互，使用户能够先查看链接内容，再确认访问。

Bug 修复：
- 修复触摸屏上黑幕内外部链接无法显示链接文本的问题，使首次点击揭示内容，再次点击才弹出外链确认。

功能增强：
- 协调黑幕点击与外链确认逻辑，并保留黑幕半隐模式及桌面端原有行为。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

确保用户可以在触摸设备上确认导航之前，查看被隐藏文本覆盖层遮挡的外部链接。

错误修复：
- 修复隐藏文本覆盖层中外部链接的触摸和触控笔交互，使第一次点击显示链接文本，第二次点击打开确认对话框。

增强功能：
- 协调隐藏文本覆盖层点击处理与外部链接确认流程，同时保留半隐藏模式和桌面鼠标行为。
- 禁用半隐藏模式时重置隐藏文本点击状态，以防止残留交互。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

确保用户在确认导航之前，可以在触控设备上查看被遮挡的外部链接文本。

错误修复：
- 修复隐藏文本覆盖层中外部链接的触控和手写笔交互，使第一次点击显示链接文本，后续点击打开确认对话框。

增强功能：
- 协调隐藏文本点击处理与外部链接确认，同时保留半隐藏模式和桌面端鼠标行为。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

允许触控用户在确认导航前查看被叠加层隐藏的外部链接。

Bug 修复：
- 修复隐藏叠加层中外部链接的触控和手写笔交互，使第一次点击显示链接文本，第二次点击打开确认对话框。

增强功能：
- 协调隐藏叠加层点击处理与外部链接确认流程，同时保留半隐藏模式和桌面端行为。
- 半隐藏切换状态发生变化时重置共享的隐藏叠加层点击状态，以防止交互状态过时。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow touch users to view external links hidden by overlays before confirming navigation.

Bug Fixes:
- Fix touch and pen interactions with external links inside hidden overlays so the first tap reveals the link text and the second tap opens the confirmation dialog.

Enhancements:
- Coordinate hidden-overlay click handling with external-link confirmation while preserving half-hidden mode and desktop behavior.
- Reset shared hidden-overlay click state when the half-hidden toggle changes to prevent stale interaction state.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

确保用户可以在触摸设备上确认导航之前，查看被隐藏文本覆盖层遮挡的外部链接。

错误修复：
- 修复隐藏文本覆盖层中外部链接的触摸和触控笔交互，使第一次点击显示链接文本，第二次点击打开确认对话框。

增强功能：
- 协调隐藏文本覆盖层点击处理与外部链接确认流程，同时保留半隐藏模式和桌面鼠标行为。
- 禁用半隐藏模式时重置隐藏文本点击状态，以防止残留交互。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

确保用户在确认导航之前，可以在触控设备上查看被遮挡的外部链接文本。

错误修复：
- 修复隐藏文本覆盖层中外部链接的触控和手写笔交互，使第一次点击显示链接文本，后续点击打开确认对话框。

增强功能：
- 协调隐藏文本点击处理与外部链接确认，同时保留半隐藏模式和桌面端鼠标行为。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

允许触控用户在确认导航前查看被叠加层隐藏的外部链接。

Bug 修复：
- 修复隐藏叠加层中外部链接的触控和手写笔交互，使第一次点击显示链接文本，第二次点击打开确认对话框。

增强功能：
- 协调隐藏叠加层点击处理与外部链接确认流程，同时保留半隐藏模式和桌面端行为。
- 半隐藏切换状态发生变化时重置共享的隐藏叠加层点击状态，以防止交互状态过时。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow touch users to view external links hidden by overlays before confirming navigation.

Bug Fixes:
- Fix touch and pen interactions with external links inside hidden overlays so the first tap reveals the link text and the second tap opens the confirmation dialog.

Enhancements:
- Coordinate hidden-overlay click handling with external-link confirmation while preserving half-hidden mode and desktop behavior.
- Reset shared hidden-overlay click state when the half-hidden toggle changes to prevent stale interaction state.

</details>

</details>

</details>

</details>

</details>