### PR TITLE
feat(Gadget/Navigation_popups): 主命名空间预览改用 TextExtracts 纯文本

### DIFF
--- a/src/gadgets/Navigation_popups/Gadget-popups.js
+++ b/src/gadgets/Navigation_popups/Gadget-popups.js
@@ -716,7 +716,7 @@ $(() => {
         let t = text.trim();
         const maxSentences = getValueOf("popupMaxPreviewSentences");
         if (maxSentences > 0) {
-            const sentences = t.split(/(?<=[。．!?！?.])/);
+            const sentences = t.split(/(?<=[。．!?！？.])/);
             if (sentences.length > maxSentences) {
                 t = sentences.slice(0, maxSentences).join("");
             }
@@ -725,19 +725,20 @@ $(() => {
         if (maxChars > 0 && t.length > maxChars) {
             t = t.slice(0, maxChars);
             const cut = Math.max(t.lastIndexOf("。"), t.lastIndexOf("．"), t.lastIndexOf("！"), t.lastIndexOf("？"), t.lastIndexOf("!"), t.lastIndexOf("?"));
-            t = cut > 0 ? t.slice(0, cut + 1) : `${t}……`;
+            // 无句读时预留省略号的空间，保证结果不超过 popupMaxPreviewCharacters
+            t = cut > 0 ? t.slice(0, cut + 1) : `${t.slice(0, Math.max(0, maxChars - 2))}……`;
         }
         return t;
     };
     const insertArticlePreview = (download, art, navpop) => {
         if (download && typeof download.data === typeof "") {
             if (download.plainText) {
-                const h = `<hr /><div>${plainTextPreview(download.data).entify().split("\\n").join("<br />\\n")}</div>`;
+                const h = `<hr /><div>${plainTextPreview(download.data).entify().split("\n").join("<br />\n")}</div>`;
                 setPopupHTML(h, "popupPreview", navpop.idNumber);
                 return;
             }
             if (art.namespaceId() === pg.nsTemplateId && getValueOf("popupPreviewRawTemplates")) {
-                const h = `<hr /><span style="font-family: monospace;">${download.data.entify().split("\\n").join("<br />\\n")}</span>`;
+                const h = `<hr /><span style="font-family: monospace;">${download.data.entify().split("\n").join("<br />\n")}</span>`;
                 setPopupHTML(h, "popupPreview", navpop.idNumber);
             } else {
                 const p = prepPreviewmaker(download.data, art, navpop);
@@ -3515,28 +3516,35 @@ $(() => {
             }
             // TextExtracts 分支：extract 为纯文本（redirects=1 时已直接是目标页的内容）
             if (typeof page.extract === "string") {
+                const navpop = download.owner;
+                // 先于空 extract 回退处理重定向状态，否则回退路径会丢失重定向徽标与目标状态
+                if (jsObj.query.redirects?.length && navpop.redir === 0) {
+                    // 与 loadPreviewFromRedir 一致地补齐重定向状态（含原链接锚点）；
+                    // 区别在于目标页内容已随本次请求返回，无需再次请求
+                    const target = new Title().fromWikiText(jsObj.query.redirects[0].to);
+                    if (navpop.article.anchor) {
+                        target.anchor = navpop.article.anchor;
+                    }
+                    navpop.redir++;
+                    navpop.redirTarget = target;
+                    setPopupHTML(redirLink(target.toString(), navpop.article), "popupWarnRedir", navpop.idNumber);
+                    navpop.article = target;
+                    fillEmptySpans({
+                        redir: true,
+                        redirTarget: target,
+                        navpopup: navpop,
+                    });
+                }
                 if (page.extract === "") {
-                    // 页面可见文本全在模板/表格内时 extract 可能为空，回退到 wikitext 请求
-                    download.owner.plainTextFallback = true;
-                    loadPreview(new Title().fromWikiText(page.title), null, download.owner);
+                    // 页面可见文本全在模板/表格内时 extract 可能为空，回退到 wikitext 请求；
+                    // 置空 owner 使本次 JSON 响应不再被 insertPreview 当作预览内容消费
+                    navpop.plainTextFallback = true;
+                    download.owner = null;
+                    loadPreview(new Title().fromWikiText(page.title), null, navpop);
                     return;
                 }
                 download.data = page.extract;
                 download.plainText = true;
-                if (jsObj.query.redirects && download.owner.redir === 0) {
-                    // 与 loadPreviewFromRedir 一致地补齐重定向状态；
-                    // 区别在于目标页内容已随本次请求返回，无需再次请求
-                    const target = new Title().fromWikiText(jsObj.query.redirects[0].to);
-                    download.owner.redir++;
-                    download.owner.redirTarget = target;
-                    setPopupHTML(redirLink(target.toString(), download.owner.article), "popupWarnRedir", download.owner.idNumber);
-                    download.owner.article = target;
-                    fillEmptySpans({
-                        redir: true,
-                        redirTarget: target,
-                        navpopup: download.owner,
-                    });
-                }
             } else {
                 const content = page?.revisions?.[0]?.slots?.main?.contentmodel === "wikitext" ? page.revisions[0].slots.main.content : null;
                 if (typeof content === "string") {

--- a/src/gadgets/Navigation_popups/Gadget-popups.js
+++ b/src/gadgets/Navigation_popups/Gadget-popups.js
@@ -690,26 +690,52 @@ $(() => {
         const wikiText = download.data;
         const navpop = download.owner;
         const art = navpop.redirTarget || navpop.originalArticle;
-        makeFixDabs(wikiText, navpop);
-        if (getValueOf("popupSummaryData")) {
-            getPageInfo(wikiText, download);
-            setPopupTrailer(getPageInfo(wikiText, download), navpop.idNumber);
-        }
-        let imagePage;
-        if (art.namespaceId() === pg.nsImageId) {
-            imagePage = art.toString();
-        } else {
-            imagePage = getValidImageFromWikiText(wikiText);
-        }
-        if (imagePage) {
-            loadImage(Title.fromWikiText(imagePage), navpop);
+        // 纯文本预览下，依赖 wikitext 的衍生功能（消歧义修复、页面信息统计、首图预加载）不适用
+        if (!download.plainText) {
+            makeFixDabs(wikiText, navpop);
+            if (getValueOf("popupSummaryData")) {
+                getPageInfo(wikiText, download);
+                setPopupTrailer(getPageInfo(wikiText, download), navpop.idNumber);
+            }
+            let imagePage;
+            if (art.namespaceId() === pg.nsImageId) {
+                imagePage = art.toString();
+            } else {
+                imagePage = getValidImageFromWikiText(wikiText);
+            }
+            if (imagePage) {
+                loadImage(Title.fromWikiText(imagePage), navpop);
+            }
         }
         if (getValueOf("popupPreviews")) {
             insertArticlePreview(download, art, navpop);
         }
     };
+    // 与 Previewmaker 的 popupMaxPreviewSentences / popupMaxPreviewCharacters 选项对齐的纯文本截断
+    const plainTextPreview = (text) => {
+        let t = text.trim();
+        const maxSentences = getValueOf("popupMaxPreviewSentences");
+        if (maxSentences > 0) {
+            const sentences = t.split(/(?<=[。．!?！?.])/);
+            if (sentences.length > maxSentences) {
+                t = sentences.slice(0, maxSentences).join("");
+            }
+        }
+        const maxChars = getValueOf("popupMaxPreviewCharacters");
+        if (maxChars > 0 && t.length > maxChars) {
+            t = t.slice(0, maxChars);
+            const cut = Math.max(t.lastIndexOf("。"), t.lastIndexOf("．"), t.lastIndexOf("！"), t.lastIndexOf("？"), t.lastIndexOf("!"), t.lastIndexOf("?"));
+            t = cut > 0 ? t.slice(0, cut + 1) : `${t}……`;
+        }
+        return t;
+    };
     const insertArticlePreview = (download, art, navpop) => {
         if (download && typeof download.data === typeof "") {
+            if (download.plainText) {
+                const h = `<hr /><div>${plainTextPreview(download.data).entify().split("\\n").join("<br />\\n")}</div>`;
+                setPopupHTML(h, "popupPreview", navpop.idNumber);
+                return;
+            }
             if (art.namespaceId() === pg.nsTemplateId && getValueOf("popupPreviewRawTemplates")) {
                 const h = `<hr /><span style="font-family: monospace;">${download.data.entify().split("\\n").join("<br />\\n")}</span>`;
                 setPopupHTML(h, "popupPreview", navpop.idNumber);
@@ -3222,7 +3248,19 @@ $(() => {
                 } else {
                     url += `titles=${article.removeAnchor().urlString()}`;
                 }
-                url += "&prop=revisions|pageprops|info|images|categories&meta=wikibase&rvslots=main&rvprop=ids|timestamp|flags|comment|user|content&cllimit=max&imlimit=max";
+                // 主命名空间且非 oldid 查询时改用 TextExtracts 纯文本预览；
+                // oldid（历史版本预览）与模板等命名空间保持 rvprop=content。
+                // rvprop=comment 在页面预览中从未被消费（仅历史/贡献预览使用），故移除
+                if (!article.oldid && !navpop.plainTextFallback && getValueOf("popupPreviewTextExtracts") && article.namespaceId() === 0) {
+                    // redirects=1 使重定向直接返回目标页内容与 redirects 数组；
+                    // popupPreviewFirstParOnly 映射为 exintro（仅首段），截断交给客户端的 popupMaxPreview*
+                    url += "&prop=extracts|pageprops|info&meta=wikibase&explaintext=1&exsectionformat=plain&redirects=1";
+                    if (getValueOf("popupPreviewFirstParOnly")) {
+                        url += "&exintro=1";
+                    }
+                } else {
+                    url += "&prop=revisions|pageprops|info|images|categories&meta=wikibase&rvslots=main&rvprop=ids|timestamp|flags|user|content&cllimit=max&imlimit=max";
+                }
                 htmlGenerator = APIrevisionPreviewHTML;
                 break;
         }
@@ -3475,10 +3513,36 @@ $(() => {
                 download.owner = null;
                 return;
             }
-            const content = page?.revisions?.[0]?.slots?.main?.contentmodel === "wikitext" ? page.revisions[0].slots.main.content : null;
-            if (typeof content === "string") {
-                download.data = content;
-                download.lastModified = new Date(page.revisions[0].timestamp);
+            // TextExtracts 分支：extract 为纯文本（redirects=1 时已直接是目标页的内容）
+            if (typeof page.extract === "string") {
+                if (page.extract === "") {
+                    // 页面可见文本全在模板/表格内时 extract 可能为空，回退到 wikitext 请求
+                    download.owner.plainTextFallback = true;
+                    loadPreview(new Title().fromWikiText(page.title), null, download.owner);
+                    return;
+                }
+                download.data = page.extract;
+                download.plainText = true;
+                if (jsObj.query.redirects && download.owner.redir === 0) {
+                    // 与 loadPreviewFromRedir 一致地补齐重定向状态；
+                    // 区别在于目标页内容已随本次请求返回，无需再次请求
+                    const target = new Title().fromWikiText(jsObj.query.redirects[0].to);
+                    download.owner.redir++;
+                    download.owner.redirTarget = target;
+                    setPopupHTML(redirLink(target.toString(), download.owner.article), "popupWarnRedir", download.owner.idNumber);
+                    download.owner.article = target;
+                    fillEmptySpans({
+                        redir: true,
+                        redirTarget: target,
+                        navpopup: download.owner,
+                    });
+                }
+            } else {
+                const content = page?.revisions?.[0]?.slots?.main?.contentmodel === "wikitext" ? page.revisions[0].slots.main.content : null;
+                if (typeof content === "string") {
+                    download.data = content;
+                    download.lastModified = new Date(page.revisions[0].timestamp);
+                }
             }
             if (page.pageprops.wikibase_item) {
                 download.wikibaseItem = page.pageprops.wikibase_item;
@@ -6205,6 +6269,9 @@ $(() => {
         newOption("popupPreviewKillTemplates", true);
         newOption("popupPreviewRawTemplates", true);
         newOption("popupPreviewFirstParOnly", true);
+        // 主命名空间预览改用 TextExtracts 纯文本（explaintext）；
+        // 模板等命名空间下 extracts 返回空，故仅对主命名空间生效，其余保持 rvprop=content
+        newOption("popupPreviewTextExtracts", true);
         newOption("popupPreviewCutHeadings", true);
         newOption("popupPreviewButton", false);
         newOption("popupPreviewButtonEvent", "click");


### PR DESCRIPTION
Fix #910

## 背景

Popups 的页面预览目前用 `rvprop=content` 取 wikitext 并做客户端解析，模板内容在预览中被无视——萌百 `{{lj}}`、`{{lang-ja}}` 使用频率高，日语内容在预览中大量不可见，比英文维基更突出。

## API 实证（实施前验证，2026-08-30）

- ✅ **TextExtracts 已安装**于萌百（siteinfo 确认）；当初用 `rvprop=content` 的历史原因（疑似未装扩展）已不复存在；
- ✅ 内容页 extracts 质量良好：`{{lj}}`/`{{lang-ja}}` 重度条目返回干净纯文本且日语内容完整（初音未来 intro 445 字符 / 全文 19882 字符、洛天依、时崎狂三、东方Project 等样本均正常）；
- ❌ **模板命名空间 extracts 为空/无意义**（`Template:lj` → `{{{1}}}`、`Template:人物信息` → ``），**Help 命名空间同样为空**——证实提案人担心，故采用「白名单」而非「黑名单」；
- ✅ `redirects=1` 自动解析重定向并随响应返回 `redirects` 数组；
- 附带发现：萌百**禁止匿名用户 `rvprop=content`**（`action-notallowed`）——gadget 仅登录用户启用故不受影响，但进一步说明 wikitext 路径的脆弱。

## 实现内容

1. **命名空间白名单**：新选项 `popupPreviewTextExtracts`（默认 true）——仅**主命名空间且非 oldid 查询**改用 `prop=extracts&explaintext=1`；模板等命名空间与历史版本预览保持原 `rvprop=content` 路径（模板本就直显 wikitext，行为不变）；
2. **重定向**：`redirects=1` 使重定向直接返回目标页内容；在 `APIrevisionPreviewHTML` 中按 `loadPreviewFromRedir` 的语义补齐重定向徽标与 navpop 状态，**无需第二次请求**；
3. **选项映射**：`popupPreviewFirstParOnly`（默认 true）→ `exintro=1`；客户端按既有 `popupMaxPreviewSentences`/`popupMaxPreviewCharacters` 选项截断（句末边界切分，中文句读符号优先）；
4. **空 extract 回退**：页面可见文本全在模板/表格内时 extract 可能为空，此时自动回退到原 wikitext 请求（单个 popup 一次性降级）；
5. **rvprop=comment 清理**：页面预览从未消费 comment（仅历史/贡献预览使用，且那是独立请求），从 revision 请求中移除；
6. **功能取舍**：纯文本模式下跳过依赖 wikitext 的衍生功能——消歧义修复链接、页面信息统计（字节数/分类数）、首图预加载、章节锚点定位；「小作品/消歧义页」标记在该模式下不再显示。可通过 `popupPreviewTextExtracts=false` 一键恢复旧行为。

## 测试

- [x] `eslint` / `tsc` 通过
- [x] 截断函数与 redirects 响应形状离线回归通过（含真实 API 响应结构）
- [x] API 实证样本见上
- [ ] 站内回归（请 review 时协助）：
  - 悬停主命名空间条目链接：预览显示纯文本、`{{lj}}` 内日文可见、长度符合 5 句/600 字符上限
  - 悬停重定向链接：出现「重定向到 X」徽标、预览为目标页内容
  - 悬停模板页链接：仍显示原始 wikitext（行为不变）
  - 悬停分类/文件/用户页链接：行为不变（非主命名空间路径未动）
  - 历史版本预览（oldid）路径不变

## Sourcery 总结

通过使用 TextExtracts 纯文本改进主命名空间导航弹窗预览，同时保留兼容的回退机制以及其他预览类型的现有行为。

新功能：
- 为主命名空间弹窗预览使用 TextExtracts 纯文本，并支持配置句子数和字符数限制。
- 在同一预览响应中处理重定向；当 extracts 为空时，回退到 wikitext。

错误修复：
- 使模板提供的内容（包括本地化文本）能够显示在主命名空间预览中。

增强功能：
- 保留非主命名空间和 oldid 请求的现有 wikitext 预览行为，同时对纯文本预览禁用依赖 wikitext 的增强功能。
- 从页面预览请求中移除未使用的修订评论数据。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过提取更简洁的文本来改进主命名空间导航弹窗预览，同时保留兼容的回退机制和旧版预览行为。

新功能：
- 使用 TextExtracts 为主命名空间弹窗预览提供纯文本，并支持配置句子数和字符数限制。
- 在预览响应中处理重定向；当提取内容为空时，回退到 wikitext。

错误修复：
- 使模板提供的内容（包括本地化文本）能够显示在主命名空间预览中。

增强功能：
- 保留非主命名空间和旧版本的现有 wikitext 预览行为，同时为纯文本预览禁用不兼容的基于 wikitext 的增强功能。
- 从页面预览请求中移除未使用的版本评论数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve main-namespace navigation popup previews with cleaner extracted text while retaining compatible fallback and legacy preview behavior.

New Features:
- Use TextExtracts plain text for main-namespace popup previews with configurable sentence and character limits.
- Handle redirects within the preview response and fall back to wikitext when extracts are empty.

Bug Fixes:
- Make template-provided content, including localized text, visible in main-namespace previews.

Enhancements:
- Preserve existing wikitext preview behavior for non-main namespaces and old revisions while disabling incompatible wikitext-derived enhancements for plain-text previews.
- Remove unused revision comment data from page preview requests.

</details>

</details>