### PR TITLE
fix(Gadget): DiscussionTools 回复后重跑讨论页小工具按钮注入

### DIFF
--- a/src/gadgets/MarkAsResolved-restricted/Gadget-MarkAsResolved-restricted.js
+++ b/src/gadgets/MarkAsResolved-restricted/Gadget-MarkAsResolved-restricted.js
@@ -236,25 +236,32 @@ $(() => {
         size: "large",
     });
     windowManager.addWindows([marDialog]);
-    for (const { self, sectionTitle } of window.libDiscussionUtil.getDiscussionHeader(["saveNotice", "MarkAsResolved"])) {
-        const button = $("<a>");
-        button.attr("href", "javascript:void(0);").prop("draggable", false).addClass("AnnTools_MarkAsResolved").text(wgULS("标记状态", "標記狀態"));
-        self.find(".mw-editsection-bracket").first()
-            .after('<span class="mw-editsection-divider"> | </span>')
-            .after(button);
-        button.on("click", () => {
-            if (!marDialog.isVisible()) {
-                marDialog.setSectionTitle(sectionTitle);
-                windowManager.openWindow(marDialog);
+    const injectButtons = () => {
+        for (const { self, sectionTitle } of window.libDiscussionUtil.getDiscussionHeader(["saveNotice", "MarkAsResolved"])) {
+            if (self.find(".AnnTools_MarkAsResolved")[0]) {
+                continue;
             }
-            return false;
-        });
-        const quicksave = self.find(".AnnTools_QuickSave");
-        if (quicksave[0]) {
-            const divider = quicksave.next(".mw-editsection-divider");
-            if (divider.length > 0) {
-                self.find(".mw-editsection .mw-editsection-bracket").first().after(divider).after(quicksave);
+            const button = $("<a>");
+            button.attr("href", "javascript:void(0);").prop("draggable", false).addClass("AnnTools_MarkAsResolved").text(wgULS("标记状态", "標記狀態"));
+            self.find(".mw-editsection-bracket").first()
+                .after('<span class="mw-editsection-divider"> | </span>')
+                .after(button);
+            button.on("click", () => {
+                if (!marDialog.isVisible()) {
+                    marDialog.setSectionTitle(sectionTitle);
+                    windowManager.openWindow(marDialog);
+                }
+                return false;
+            });
+            const quicksave = self.find(".AnnTools_QuickSave");
+            if (quicksave[0]) {
+                const divider = quicksave.next(".mw-editsection-divider");
+                if (divider.length > 0) {
+                    self.find(".mw-editsection .mw-editsection-bracket").first().after(divider).after(quicksave);
+                }
             }
         }
-    }
+    };
+    injectButtons();
+    window.libDiscussionUtil.onContentChange(injectButtons);
 });

--- a/src/gadgets/MarkAsResolved/Gadget-MarkAsResolved.js
+++ b/src/gadgets/MarkAsResolved/Gadget-MarkAsResolved.js
@@ -244,25 +244,32 @@ $(() => {
         size: "large",
     });
     windowManager.addWindows([marDialog]);
-    for (const { self, sectionTitle } of window.libDiscussionUtil.getDiscussionHeader(["saveNotice", "MarkAsResolved"])) {
-        const button = $("<a>");
-        button.attr("href", "javascript:void(0);").prop("draggable", false).addClass("AnnTools_MarkAsResolved").text(wgULS("标记状态", "標記狀態"));
-        self.find(".mw-editsection-bracket").first()
-            .after('<span class="mw-editsection-divider"> | </span>')
-            .after(button);
-        button.on("click", () => {
-            if (!marDialog.isVisible()) {
-                marDialog.setSectionTitle(sectionTitle);
-                windowManager.openWindow(marDialog);
+    const injectButtons = () => {
+        for (const { self, sectionTitle } of window.libDiscussionUtil.getDiscussionHeader(["saveNotice", "MarkAsResolved"])) {
+            if (self.find(".AnnTools_MarkAsResolved")[0]) {
+                continue;
             }
-            return false;
-        });
-        const quicksave = self.find(".AnnTools_QuickSave");
-        if (quicksave[0]) {
-            const divider = quicksave.next(".mw-editsection-divider");
-            if (divider.length > 0) {
-                self.find(".mw-editsection .mw-editsection-bracket").first().after(divider).after(quicksave);
+            const button = $("<a>");
+            button.attr("href", "javascript:void(0);").prop("draggable", false).addClass("AnnTools_MarkAsResolved").text(wgULS("标记状态", "標記狀態"));
+            self.find(".mw-editsection-bracket").first()
+                .after('<span class="mw-editsection-divider"> | </span>')
+                .after(button);
+            button.on("click", () => {
+                if (!marDialog.isVisible()) {
+                    marDialog.setSectionTitle(sectionTitle);
+                    windowManager.openWindow(marDialog);
+                }
+                return false;
+            });
+            const quicksave = self.find(".AnnTools_QuickSave");
+            if (quicksave[0]) {
+                const divider = quicksave.next(".mw-editsection-divider");
+                if (divider.length > 0) {
+                    self.find(".mw-editsection .mw-editsection-bracket").first().after(divider).after(quicksave);
+                }
             }
         }
-    }
+    };
+    injectButtons();
+    window.libDiscussionUtil.onContentChange(injectButtons);
 });

--- a/src/gadgets/SectionPermanentLink/Gadget-SectionPermanentLink.js
+++ b/src/gadgets/SectionPermanentLink/Gadget-SectionPermanentLink.js
@@ -1,45 +1,52 @@
 "use strict";
 $(() => {
     if (mw.config.get("wgNamespaceNumber") % 2 === 1 && mw.config.get("wgPageName") !== "萌娘百科_talk:讨论版" || mw.config.get("wgPageName").startsWith("萌娘百科:管理员通告版")) {
-        const inHistory = !document.getElementsByClassName("mw-editsection")[0] || $(".mw-editsection").css("display") === "none";
         const buttonText = wgULS("固定链接", "固定連結");
-        $("#mw-content-text .mw-parser-output h2").each((_, ele) => {
-            const $ele = $(ele);
-            const $editsection = $(ele).next(".mw-editsection");
-            const $divider = $('<span class="mw-editsection-divider"> | </span>');
-            const $permanentLink = $("<a>")
-                .attr("data-thread-id", mw.util.escapeIdForLink($ele.attr("id")))
-                .addClass("section-permanent-link")
-                .text(buttonText);
-            if (!inHistory) {
-                $editsection
-                    .find(".mw-editsection-bracket")
-                    .first()
-                    .after($divider)
-                    .after($permanentLink);
-                const $marButton = $editsection.find(".AnnTools_MarkAsResolved");
-                if ($marButton[0]) {
-                    const $marDivider = $marButton.next(".mw-editsection-divider");
-                    if ($marDivider.length > 0) {
-                        $marDivider.after($divider).after($permanentLink);
-                    }
+        const injectButtons = () => {
+            const inHistory = !document.getElementsByClassName("mw-editsection")[0] || $(".mw-editsection").css("display") === "none";
+            $("#mw-content-text .mw-parser-output h2").each((_, ele) => {
+                const $ele = $(ele);
+                const $editsection = $(ele).next(".mw-editsection");
+                if ($editsection.find(".section-permanent-link")[0] || $ele.find(".section-permanent-link")[0]) {
+                    return;
                 }
-            } else {
-                const permanentLinkButton = $('<span class="mw-editsection" style="display:inline!important"></span>');
-                permanentLinkButton.append(
-                    '<span class="mw-editsection-bracket">[</span>',
-                    $permanentLink,
-                    '<span class="mw-editsection-bracket">]</span>',
-                );
-                $ele.find(".mw-headline").after(permanentLinkButton);
-            }
-            $permanentLink.on("click", () => {
-                navigator.clipboard.writeText(`[[Special:PermanentLink/${mw.config.get("wgRevisionId")}#${$permanentLink.data("thread-id")}]]`);
-                $permanentLink.text(wgULS("复制成功", "復製成功"));
-                setTimeout(() => {
-                    $permanentLink.text(buttonText);
-                }, 2000);
+                const $divider = $('<span class="mw-editsection-divider"> | </span>');
+                const $permanentLink = $("<a>")
+                    .attr("data-thread-id", mw.util.escapeIdForLink($ele.attr("id")))
+                    .addClass("section-permanent-link")
+                    .text(buttonText);
+                if (!inHistory) {
+                    $editsection
+                        .find(".mw-editsection-bracket")
+                        .first()
+                        .after($divider)
+                        .after($permanentLink);
+                    const $marButton = $editsection.find(".AnnTools_MarkAsResolved");
+                    if ($marButton[0]) {
+                        const $marDivider = $marButton.next(".mw-editsection-divider");
+                        if ($marDivider.length > 0) {
+                            $marDivider.after($divider).after($permanentLink);
+                        }
+                    }
+                } else {
+                    const permanentLinkButton = $('<span class="mw-editsection" style="display:inline!important"></span>');
+                    permanentLinkButton.append(
+                        '<span class="mw-editsection-bracket">[</span>',
+                        $permanentLink,
+                        '<span class="mw-editsection-bracket">]</span>',
+                    );
+                    $ele.find(".mw-headline").after(permanentLinkButton);
+                }
+                $permanentLink.on("click", () => {
+                    navigator.clipboard.writeText(`[[Special:PermanentLink/${mw.config.get("wgRevisionId")}#${$permanentLink.data("thread-id")}]]`);
+                    $permanentLink.text(wgULS("复制成功", "復製成功"));
+                    setTimeout(() => {
+                        $permanentLink.text(buttonText);
+                    }, 2000);
+                });
             });
-        });
+        };
+        injectButtons();
+        window.libDiscussionUtil.onContentChange(injectButtons);
     }
 });

--- a/src/gadgets/SectionPermanentLink/definition.yaml
+++ b/src/gadgets/SectionPermanentLink/definition.yaml
@@ -27,6 +27,7 @@ peers: []
 
 dependencies:
   - ext.gadget.site-lib
+  - ext.gadget.libDiscussionUtil
 
 _sites:
   - zh

--- a/src/gadgets/libDiscussionUtil/Gadget-libDiscussionUtil.js
+++ b/src/gadgets/libDiscussionUtil/Gadget-libDiscussionUtil.js
@@ -11,4 +11,17 @@ window.libDiscussionUtil = {
         const sectionTitle = self.find(".mw-headline, h2[data-mw-thread-id]").attr("id");
         return { self, sectionTitle };
     }).filter((n) => n !== null),
+    /**
+     * DiscussionTools 在发布回复、添加话题等操作后会将 `.mw-parser-output` 整体替换，
+     * 一次性注入的元素与事件随之丢失，替换完成后它会触发 `wikipage.content` 钩子。
+     * 借助该钩子重跑注入逻辑以恢复被移除的元素。
+     *
+     * 刻意丢弃钩子传入的 `$content` 参数：它可能是回复预览区等子容器，
+     * 重跑时应始终按顶层选择器全页扫描；`callback` 自身需保证可重入（幂等）。
+     *
+     * @param {() => void} callback
+     */
+    onContentChange: (callback) => {
+        mw.hook("wikipage.content").add(() => callback());
+    },
 };

--- a/src/gadgets/quickMoveThread/Gadget-quickMoveThread.js
+++ b/src/gadgets/quickMoveThread/Gadget-quickMoveThread.js
@@ -234,24 +234,28 @@ $(() => {
         });
         windowManager.addWindows([qmtDialog]);
 
-        $(".mw-parser-output .mw-heading h2").each((_, ele) => {
-            const $ele = $(ele).parent();
-            if (!$ele.find(".mw-editsection")[0] || $ele.next(".movedToNotice, .movedFromNotice, .saveNotice")[0]) {
-                return;
-            }
-            const section = +new URL($ele.find('.mw-editsection a[href*="action=edit"][href*="section="]').attr("href"), location.origin).searchParams.get("section");
-            const anchor = $(ele).attr("id");
-            const button = $("<a>").attr("href", "#").prop("draggable", false).addClass("lr-qmt-link").text(wgULS("移动", "移動")).on("click", (e) => {
-                e.preventDefault();
-                windowManager.openWindow(qmtDialog, { section, anchor });
+        const injectButtons = () => {
+            $(".mw-parser-output .mw-heading h2").each((_, ele) => {
+                const $ele = $(ele).parent();
+                if (!$ele.find(".mw-editsection")[0] || $ele.find(".lr-qmt-link")[0] || $ele.next(".movedToNotice, .movedFromNotice, .saveNotice")[0]) {
+                    return;
+                }
+                const section = +new URL($ele.find('.mw-editsection a[href*="action=edit"][href*="section="]').attr("href"), location.origin).searchParams.get("section");
+                const anchor = $(ele).attr("id");
+                const button = $("<a>").attr("href", "#").prop("draggable", false).addClass("lr-qmt-link").text(wgULS("移动", "移動")).on("click", (e) => {
+                    e.preventDefault();
+                    windowManager.openWindow(qmtDialog, { section, anchor });
+                });
+                const $splButton = $ele.find(".section-permanent-link");
+                if ($splButton[0]) {
+                    $splButton.next(".mw-editsection-divider").after('<span class="mw-editsection-divider"> | </span>').after(button);
+                } else {
+                    $ele.find(".mw-editsection-bracket").first().after('<span class="mw-editsection-divider"> | </span>').after(button);
+                }
             });
-            const $splButton = $ele.find(".section-permanent-link");
-            if ($splButton[0]) {
-                $splButton.next(".mw-editsection-divider").after('<span class="mw-editsection-divider"> | </span>').after(button);
-            } else {
-                $ele.find(".mw-editsection-bracket").first().after('<span class="mw-editsection-divider"> | </span>').after(button);
-            }
-        });
+        };
+        injectButtons();
+        window.libDiscussionUtil.onContentChange(injectButtons);
     } catch (e) {
         const parseError = (errLike, _space) => {
             let space = _space;

--- a/src/gadgets/quickMoveThread/definition.yaml
+++ b/src/gadgets/quickMoveThread/definition.yaml
@@ -32,6 +32,7 @@ dependencies:
   - ext.gadget.site-lib
   - ext.gadget.LocalObjectStorage
   - ext.gadget.libPolyfill
+  - ext.gadget.libDiscussionUtil
 
 _sites:
   - zh

--- a/src/gadgets/quickSave/Gadget-quickSave.js
+++ b/src/gadgets/quickSave/Gadget-quickSave.js
@@ -324,25 +324,32 @@ $(() => {
     $body.append(windowManager.$element);
     const qsDialog = new QSWindow();
     windowManager.addWindows([qsDialog]);
-    for (const { self, sectionTitle } of window.libDiscussionUtil.getDiscussionHeader(["saveNotice"])) {
-        const button = $("<a>");
-        button.attr("href", "javascript:void(0);").prop("draggable", false).addClass("AnnTools_QuickSave").text(wgULS("快速存档", "快速存檔"));
-        self.find(".mw-editsection-bracket").first()
-            .after('<span class="mw-editsection-divider"> | </span>')
-            .after(button);
-        button.on("click", () => {
-            if (!qsDialog.isVisible()) {
-                qsDialog.setSectionTitle(sectionTitle);
-                windowManager.openWindow(qsDialog);
+    const injectButtons = () => {
+        for (const { self, sectionTitle } of window.libDiscussionUtil.getDiscussionHeader(["saveNotice"])) {
+            if (self.find(".AnnTools_QuickSave")[0]) {
+                continue;
             }
-            return false;
-        });
-        const quicksave = self.find(".AnnTools_QuickSave");
-        if (self.find(".AnnTools_MarkAsResolved")[0]) {
-            const divider = quicksave.next(".mw-editsection-divider");
-            if (divider.length > 0) {
-                self.find(".mw-editsection .mw-editsection-bracket").first().after(divider).after(quicksave);
+            const button = $("<a>");
+            button.attr("href", "javascript:void(0);").prop("draggable", false).addClass("AnnTools_QuickSave").text(wgULS("快速存档", "快速存檔"));
+            self.find(".mw-editsection-bracket").first()
+                .after('<span class="mw-editsection-divider"> | </span>')
+                .after(button);
+            button.on("click", () => {
+                if (!qsDialog.isVisible()) {
+                    qsDialog.setSectionTitle(sectionTitle);
+                    windowManager.openWindow(qsDialog);
+                }
+                return false;
+            });
+            const quicksave = self.find(".AnnTools_QuickSave");
+            if (self.find(".AnnTools_MarkAsResolved")[0]) {
+                const divider = quicksave.next(".mw-editsection-divider");
+                if (divider.length > 0) {
+                    self.find(".mw-editsection .mw-editsection-bracket").first().after(divider).after(quicksave);
+                }
             }
         }
-    }
+    };
+    injectButtons();
+    window.libDiscussionUtil.onContentChange(injectButtons);
 });

--- a/src/gadgets/quickSave/definition.yaml
+++ b/src/gadgets/quickSave/definition.yaml
@@ -31,6 +31,7 @@ dependencies:
   - ext.gadget.libPolyfill
   - ext.gadget.libOOUIDialog
   - ext.gadget.site-lib
+  - ext.gadget.libDiscussionUtil
 
 _sites:
   - zh


### PR DESCRIPTION
fix #1033

## 问题

讨论页的「回复」按钮来自 MediaWiki 的 DiscussionTools 扩展。发布回复（或添加话题）后，DT 的 `updatePageContents()` 会用 `replaceWith` 将整个 `.mw-parser-output` 整体替换（[controller.js:723](https://gerrit.wikimedia.org/g/mediawiki/extensions/DiscussionTools/+/refs/heads/master/modules/controller.js)），页面加载时一次性注入的按钮及事件随之全部丢失。受影响的是全部「按钮注入型」小工具：

- quickSave（快速存档）
- MarkAsResolved / MarkAsResolved-restricted（标记状态）
- quickMoveThread（移动）
- SectionPermanentLink（固定链接）

替换完成后 DT 会触发 `mw.hook("wikipage.content")`（controller.js:751），这是官方给外部脚本的重挂入口。

## 改动

重跑逻辑收敛到 libDiscussionUtil（讨论中确定的方案）：

1. **libDiscussionUtil** 新增 `onContentChange(callback)`：封装 `wikipage.content` 钩子注册。刻意丢弃钩子的 `` 参数——它可能是回复预览区等子容器（ReplyWidget 预览也会 fire 该钩子），重跑时始终按顶层选择器全页扫描。
2. **五个小工具**统一改造：注入循环抽成可重入的 `injectButtons()`，加幂等守卫（已存在按钮则跳过），先执行一次再注册钩子重跑。OO.ui 对话框类与 WindowManager 单例保持在函数外，不重建。
3. **definition.yaml**：quickMoveThread、SectionPermanentLink 新增 `ext.gadget.libDiscussionUtil` 依赖。

与 displayname-show（687fdeaf）、modIconPrep（59ad858d）此前落地的「内容变更后重跑」模式一致。

## 已知取舍

- 重跑后同段落内按钮左右排序可能与首次加载略有差异（各小工具间存在交叉排序逻辑），纯外观问题；
- `wikipage.content` 钩子有 memory（注册即重放），首次加载可能双跑，由幂等守卫兜底；
- 不加 MutationObserver：回复、添加话题两条路径均确认走钩子，Observer 只增加重复注入风险。

## 验证

- [x] 改动文件 eslint 通过（0 错误 0 警告）
- [x] `npm run build` 全量通过，产物已抽查确认钩子逻辑编入
- [ ] 线上手工验证（需 patroller+ 权限）：
  - 讨论版页面发布回复后，「快速存档 / 标记状态 / 移动」按钮恢复、弹窗正常打开
  - 快速存档、标记状态、移动各实测一次无回归
  - 「添加话题」路径同验（走同一钩子）
  - SectionPermanentLink（仅需登录账号）：任意讨论页回复后「固定链接」恢复、无重复、点击可复制
  - 初始加载回归：无重复按钮（验证幂等守卫）

## Sourcery 摘要

在 DiscussionTools 动态更新内容后，继续显示讨论页面小工具按钮。

错误修复：
- 在 DiscussionTools 于回复或创建新主题后替换页面内容时，恢复讨论小工具按钮。

改进：
- 集中处理内容变更钩子，并确保受影响的讨论小工具中的按钮注入操作具有幂等性。
- 为使用内容变更重新注入功能的小工具添加共享讨论工具依赖。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在 DiscussionTools 动态更新内容后，确保讨论小工具按钮仍然可用且功能正常。

错误修复：
- 在 DiscussionTools 因回复或新主题而替换页面内容后，恢复讨论小工具按钮。

增强功能：
- 集中处理内容变更钩子，并使受影响的讨论小工具中的按钮注入操作具备幂等性。

杂项：
- 为需要在内容更新后重新注入按钮的小工具添加共享讨论工具依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Keep discussion gadget buttons available and functional after dynamic DiscussionTools content updates.

Bug Fixes:
- Restore discussion gadget buttons after DiscussionTools replaces page content following replies or new topics.

Enhancements:
- Centralize content-change hook handling and make button injection idempotent across the affected discussion gadgets.

Chores:
- Add the shared discussion utility dependency to gadgets that re-inject buttons after content updates.

</details>

</details>