### PR TITLE
docs(Gadget/Navigation_popups): point popups JS source to standalone repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@ src/*.json linguist-generated=false
 src/**/*.yaml linguist-generated=false
 src/*.yaml linguist-generated=false
 src/gadgets/libPolyfill/Gadget-libPolyfill.*.js linguist-generated=true
+src/gadgets/Navigation_popups/Gadget-popups.js linguist-generated=true
 
 # From browserify
 src/gadgets/libHashwasm/Gadget-libHashwasm.js linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
     - `definition.{站点代号}.yaml` （可选）保存小工具的站点配置，包括依赖项、所需权限等，在处理对应站点的配置文件时，将会在以覆盖方式合并到上述配置后生成配置文件，如 [`src/gadgets/HotCat/definition.commons.yaml`](src/gadgets/HotCat/definition.commons.yaml)；
     - `.eslintrc.yaml` （可选）用以阻止 eslint 在某些文件上进行检查，常见于来自 npm 和指定页面的代码；
     - `*.js` 和 `*.css` 为小工具代码，文件名为萌娘百科上对应页面的页面名；
+    - 特例：[`src/gadgets/Navigation_popups/Gadget-popups.js`](src/gadgets/Navigation_popups/Gadget-popups.js) 为构建产物，其源码在 [Navigation_popups 仓库](https://github.com/MoegirlPediaInterfaceAdmins/Navigation_popups) 中按上游原始文件结构拆分维护，由该仓库构建后回传本仓库，请勿在本仓库直接修改；同目录的 `Gadget-popups.css` 仍在本仓库维护；
   - [`src/groups`](src/groups) 以文件夹形式保存用户组级别代码，每一个文件夹都对应一个子站点，每一个站点文件夹的子文件夹对应一个用户组，里面包含 `*.js` 和 `*.css` 等代码，文件名为萌娘百科上对应页面的页面名；
   - [`src/global`](src/global) 保存全站代码，每一个文件夹都对应一个站点，里面包含 `*.js` 和 `*.css` 等代码，文件名为萌娘百科上对应页面的页面名。
 

--- a/src/gadgets/Navigation_popups/definition.yaml
+++ b/src/gadgets/Navigation_popups/definition.yaml
@@ -1,3 +1,7 @@
+# Navigation popups 的 JS 源码已迁移至独立仓库维护：
+# https://github.com/MoegirlPediaInterfaceAdmins/Navigation_popups
+# 本目录下的 Gadget-popups.js 为该仓库构建后回传的产物，请勿在本仓库直接修改；
+# Gadget-popups.css 仍在本仓库维护。
 ResourceLoader: true
 
 hidden: false


### PR DESCRIPTION
## 概述

Navigation popups 的 JS 源码已迁移至独立仓库 [Navigation_popups](https://github.com/MoegirlPediaInterfaceAdmins/Navigation_popups) 维护：源码按维基百科上游原始文件结构拆分为 33 个片段，在该仓库构建为单文件产物后回传本仓库，仍由本仓库既有流水线（postCommit CI → webhook）部署。

本 PR 为配套改动，**不改动任何产物文件内容**：

- [`README.md`](https://github.com/MoegirlPediaInterfaceCodes/blob/docs/navigation-popups-standalone-repo/README.md)：在 `src/gadgets` 目录说明处补充特例条目，指向新仓库；
- [`.gitattributes`](https://github.com/MoegirlPediaInterfaceCodes/blob/docs/navigation-popups-standalone-repo/.gitattributes)：基线段新增 `src/gadgets/Navigation_popups/Gadget-popups.js linguist-generated=true`（产物标记为生成文件，与 libPolyfill 等既有先例一致；写在 `# From` 自动段之外，不会被 postCommit 的 linguist-generated 生成器重写）；
- [`src/gadgets/Navigation_popups/definition.yaml`](https://github.com/MoegirlPediaInterfaceCodes/blob/docs/navigation-popups-standalone-repo/src/gadgets/Navigation_popups/definition.yaml)：顶部注释说明源码位置（YAML 注释，不影响 v8r 校验）。

`Gadget-popups.css` 与 `definition.yaml` 本体仍在（且仅在本仓库）维护。

## 迁移基线

迁移基线为本仓库 `5adc9438f079d6b77157ff9f3649008f60ac915a` 时的 `Gadget-popups.js`（6529 行），新仓库已机械化验证 33 片段按序拼接与该文件**字节级完全一致**（`cmp` 为空），功能等价无需线上验证。

## 后续

- 此后 popups 的 JS 修改请一律在 [Navigation_popups 仓库](https://github.com/MoegirlPediaInterfaceAdmins/Navigation_popups) 进行（该仓库 CI 对拼接产物跑与本仓库等价的 eslint / tsc / terser 门禁）；
- 该仓库 Release 工作流当前以 artifact 形式交付产物，向本仓库自动开 PR 的回传任务已就绪但暂时停用（`if: false`），待 PAT 配置后启用。

## Sourcery 总结

记录 Navigation popups JavaScript 源代码维护迁移至独立仓库的过程，同时保留现有的生成产物和本地 CSS 配置。

增强：
- 将 Navigation popups JavaScript 记录为由独立的 Navigation_popups 仓库维护和构建的生成产物，同时保留在本仓库中对 CSS 的维护。

文档：
- 更新小工具文档和元数据注释，加入 Navigation_popups 源代码仓库信息以及生成文件维护指南。

杂务：
- 在 Git 属性中将 Navigation popups JavaScript 构建产物标记为生成文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document the migration of Navigation popups JavaScript source maintenance to the standalone repository while preserving the existing generated artifact and local CSS configuration.

Enhancements:
- Document Navigation popups JavaScript as a generated artifact maintained and built in the standalone Navigation_popups repository, while retaining CSS maintenance in this repository.

Documentation:
- Update gadget documentation and metadata comments with the Navigation_popups source repository and generated-file maintenance guidance.

Chores:
- Mark the Navigation popups JavaScript build artifact as generated in Git attributes.

</details>