### PR TITLE
fix(styles): broaden language-aware font selector coverage

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -199,5 +199,6 @@
         "Group/user"
     ],
     "conventionalCommits.storeScopesGlobally": false,
-    "github.copilot.chat.organizationInstructions.enabled": false
+    "github.copilot.chat.organizationInstructions.enabled": false,
+    "css.format.spaceAroundSelectorSeparator": true
 }

--- a/src/gadgets/GothicMoe/Gadget-GothicMoe.css
+++ b/src/gadgets/GothicMoe/Gadget-GothicMoe.css
@@ -16,7 +16,7 @@ body.skin-moeskin {
     font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif, NospzGothicMoe;
 }
 
-html :is(i, [style*="italic"i]) span[lang="ja"i],
-html span[lang="ja"i] :is(i, [style*="italic"i]) {
+html :is(i, [style*="italic"i]) :is(.lang-text, span, bdi)[lang]:lang(ja),
+html :is(.lang-text, span, bdi)[lang]:lang(ja) :is(i, [style*="italic"i]) {
     font-family: JapaneseItalic, sans-serif, NospzGothicMoe, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }

--- a/src/gadgets/site-styles/Gadget-site-styles.css
+++ b/src/gadgets/site-styles/Gadget-site-styles.css
@@ -278,16 +278,17 @@
  * 如果你使用思源黑体（非 CN、JP、KO、TW 版）、Noto Sans CJK 显示文字的话就有可能看到效果。
  * 关于上述这个 CSS 属性的用法，参阅：https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings 注意：此文引用的 OpenType Feature Tags list 同样需要关注。
  * 如有任何问题请即刻禁用之
- * Nbdd0121: 将原来的[lang]改为span[lang]，这样就不会影响非{{lang}}的[lang]了 (e.g. div#mw-content-text)
+ * [[User:Nbdd0121]]：将原来的[lang]改为span[lang]，这样就不会影响非{{lang}}的[lang]了 (e.g. div#mw-content-text)
+ * [[User:默默无闻的杜邦线]]：将 span[lang] 扩展为 :is(.lang-text, span, bdi)[lang]；其中 .lang-text 类用于{{lang/div}}输出的 div[lang]，bdi[lang] 用于后续{{lang}}改动，保留 span 以兼容现有写法
+ * 使用 :lang(ja) 匹配带有子标签的日语语言标签
+ * 移除 font-feature-settings 属性；根据 .browserslistrc 的支持范围，目标浏览器皆已默认启用 locl 特性
  */
-span[lang] {
+:is(.lang-text, span, bdi)[lang] {
     font-family: initial;
-    font-feature-settings: "locl" on;
-    -webkit-font-feature-settings: "locl" on;
 }
 
-[style*="font:" i] span[lang],
-[style*="font-family:" i] span[lang] {
+[style*="font:" i] :is(.lang-text, span, bdi)[lang],
+[style*="font-family:" i] :is(.lang-text, span, bdi)[lang] {
     font-family: inherit;
 }
 
@@ -297,13 +298,13 @@ span[lang] {
     src: local(meiryo);
 }
 
-:is(i, [style*="italic" i]) span[lang="ja" i],
-span[lang="ja" i] :is(i, [style*="italic" i]) {
+:is(i, [style*="italic" i]) :is(.lang-text, span, bdi)[lang]:lang(ja),
+:is(.lang-text, span, bdi)[lang]:lang(ja) :is(i, [style*="italic" i]) {
     font-family: JapaneseItalic, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
-:is([style*="font:" i], [style*="font-family:" i]) :is(i, [style*="italic" i]) span[lang="ja" i],
-:is([style*="font:" i], [style*="font-family:" i]) span[lang="ja" i] :is(i, [style*="italic" i]) {
+:is([style*="font:" i], [style*="font-family:" i]) :is(i, [style*="italic" i]) :is(.lang-text, span, bdi)[lang]:lang(ja),
+:is([style*="font:" i], [style*="font-family:" i]) :is(.lang-text, span, bdi)[lang]:lang(ja) :is(i, [style*="italic" i]) {
     font-family: inherit;
 }
 


### PR DESCRIPTION
* 将 `span[lang]` 扩展为 `:is(.lang-text, span, bdi)[lang]`；其中 `.lang-text` 类用于{{lang/div}}输出的 `div[lang]`，`bdi[lang]` 用于后续{{lang}}改动，保留 span 以兼容现有写法
 * 使用 `:lang(ja)` 匹配带有子标签的日语语言标签
 * 移除 `font-feature-settings` 属性；根据 .browserslistrc 的支持范围，目标浏览器皆已默认启用 locl 特性
 * 增加 `css.format.spaceAroundSelectorSeparator`；依照目前已有的写法添加

## Sourcery 总结

扩展语言感知字体选择器，并简化本地化排版处理。

Bug 修复：
- 扩展语言感知字体样式，使其涵盖由 div、span 和 bdi 元素渲染的本地化文本。
- 改进对嵌套语言标签的日语语言检测，并保留日语斜体字体处理。

增强功能：
- 移除显式的 locl 字体特性设置，因为受支持的浏览器现在默认启用该功能。
- 更新 CSS 格式配置及相关样式归属注释。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Broaden language-aware font selectors and simplify localized typography handling.

Bug Fixes:
- Broaden language-aware font styling to cover localized text rendered by div, span, and bdi elements.
- Improve Japanese language detection for nested language tags and preserve italic Japanese font handling.

Enhancements:
- Remove explicit locl font-feature settings now that supported browsers enable it by default.
- Update CSS formatting configuration and related style attribution comments.

</details>