### PR TITLE
fix(Gadget/draftInfo): update button text for clarity in draft notice

### DIFF
--- a/src/gadgets/draftInfo/Gadget-draftInfo.js
+++ b/src/gadgets/draftInfo/Gadget-draftInfo.js
@@ -73,7 +73,7 @@ $(() => {
                         <div class="draft-notice-title">${wgULS("提示：本页面是【", "提示：本頁面是【")}<a href="/${encodeURIComponent(wgTitle)}">${mw.html.escape(wgTitle)}</a>${wgULS("】的", "】的")}<a href="/%E8%90%8C%E5%A8%98%E7%99%BE%E7%A7%91:%E8%8D%89%E7%A8%BF%E6%96%B9%E9%92%88">${wgULS("草稿", "草稿")}</a></div>
                         <ul>
                             <li id="draft-discussion-notice">${buildDiscussionNotice(false)}</li>
-                            <li>${wgULS("如果草稿已经完善，您可以", "如果草稿已經完善，您可以")}${enableButton ? wgULS("点击右侧的按钮", "點擊右側的按鈕") : wgULS("自行", "自行")}${wgULS("发布草稿。", "發佈草稿。")}</li>
+                            <li>${wgULS("如果草稿已经完善，您可以", "如果草稿已經完善，您可以")}${enableButton ? wgULS("使用按钮", "使用按鈕") : wgULS("自行", "自行")}${wgULS("发布草稿。", "發佈草稿。")}</li>
                         </ul>
                     </div>
                     ${enableButton


### PR DESCRIPTION
`点击右侧的按钮` → `使用按钮`：移动端按钮不在右侧，同时无障碍的情况下难以认知位置关系

## Sourcery 摘要

错误修复：
- 通过在简体中文和繁体中文中，将依赖位置的按钮文本替换为更易理解的“使用按钮”措辞，明确草稿通知说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Clarify the draft notice instruction by replacing the position-dependent button text with a more accessible “use the button” wording in Simplified and Traditional Chinese.

</details>