### PR TITLE
refactor: simplify font handling and broaden Japanese italic selectors

### DIFF
--- a/src/gadgets/GothicMoe/Gadget-GothicMoe.css
+++ b/src/gadgets/GothicMoe/Gadget-GothicMoe.css
@@ -7,13 +7,13 @@
 }
 
 .mw-body-content :is(h1, h2) {
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif, NospzGothicMoe;
+    font-family: sans-serif, NospzGothicMoe, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
 h1#firstHeading,
 body.skin-vector-2022,
 body.skin-moeskin {
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif, NospzGothicMoe;
+    font-family: sans-serif, NospzGothicMoe, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
 html :is(i, [style*="italic"i]) :is(.lang-text, span, bdi)[lang]:lang(ja),

--- a/src/gadgets/GothicMoe/Gadget-GothicMoe.css
+++ b/src/gadgets/GothicMoe/Gadget-GothicMoe.css
@@ -16,7 +16,8 @@ body.skin-moeskin {
     font-family: sans-serif, NospzGothicMoe, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
-html :is(i, [style*="italic"i]) :is(.lang-text, span, bdi)[lang]:lang(ja),
-html :is(.lang-text, span, bdi)[lang]:lang(ja) :is(i, [style*="italic"i]) {
+html :is(i, em, [style*="italic" i]) [lang]:lang(ja),
+html [lang]:lang(ja):is(i, em, [style*="italic" i]),
+html [lang]:lang(ja) :is(i, em, [style*="italic" i]) {
     font-family: JapaneseItalic, sans-serif, NospzGothicMoe, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }

--- a/src/gadgets/site-styles/Gadget-site-styles.css
+++ b/src/gadgets/site-styles/Gadget-site-styles.css
@@ -271,27 +271,6 @@
     margin-top: 0;
 }
 
-/*
- * 感谢[[User:Great Brightstar]]的贡献，源码来自[[special:diff/834104]]
- * 以下是原注释：
- * 在这里使用 font-feature-settings 属性会让使用“lang”标签的元素强制使用 OpenType 技术显示本地化的变体字（通过激活 locl 标签，即便浏览器本身不直接激活）。
- * 如果你使用思源黑体（非 CN、JP、KO、TW 版）、Noto Sans CJK 显示文字的话就有可能看到效果。
- * 关于上述这个 CSS 属性的用法，参阅：https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings 注意：此文引用的 OpenType Feature Tags list 同样需要关注。
- * 如有任何问题请即刻禁用之
- * [[User:Nbdd0121]]：将原来的[lang]改为span[lang]，这样就不会影响非{{lang}}的[lang]了 (e.g. div#mw-content-text)
- * [[User:默默无闻的杜邦线]]：将 span[lang] 扩展为 :is(.lang-text, span, bdi)[lang]；其中 .lang-text 类用于{{lang/div}}输出的 div[lang]，bdi[lang] 用于后续{{lang}}改动，保留 span 以兼容现有写法
- * 使用 :lang(ja) 匹配带有子标签的日语语言标签
- * 移除 font-feature-settings 属性；根据 .browserslistrc 的支持范围，目标浏览器皆已默认启用 locl 特性
- */
-:is(.lang-text, span, bdi)[lang] {
-    font-family: initial;
-}
-
-[style*="font:" i] :is(.lang-text, span, bdi)[lang],
-[style*="font-family:" i] :is(.lang-text, span, bdi)[lang] {
-    font-family: inherit;
-}
-
 /* 日语斜体 */
 @font-face {
     font-family: JapaneseItalic;

--- a/src/gadgets/site-styles/Gadget-site-styles.css
+++ b/src/gadgets/site-styles/Gadget-site-styles.css
@@ -283,6 +283,7 @@
     font-family: JapaneseItalic, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
+:is([style*="font:" i], [style*="font-family:" i]):is(i, em, [style*="italic" i]) [lang]:lang(ja),
 :is([style*="font:" i], [style*="font-family:" i]) :is(i, em, [style*="italic" i]) [lang]:lang(ja),
 :is([style*="font:" i], [style*="font-family:" i]) [lang]:lang(ja):is(i, em, [style*="italic" i]),
 :is([style*="font:" i], [style*="font-family:" i]) [lang]:lang(ja) :is(i, em, [style*="italic" i]) {

--- a/src/gadgets/site-styles/Gadget-site-styles.css
+++ b/src/gadgets/site-styles/Gadget-site-styles.css
@@ -277,13 +277,15 @@
     src: local(meiryo);
 }
 
-:is(i, [style*="italic" i]) :is(.lang-text, span, bdi)[lang]:lang(ja),
-:is(.lang-text, span, bdi)[lang]:lang(ja) :is(i, [style*="italic" i]) {
+:is(i, em, [style*="italic" i]) [lang]:lang(ja),
+[lang]:lang(ja):is(i, em, [style*="italic" i]),
+[lang]:lang(ja) :is(i, em, [style*="italic" i]) {
     font-family: JapaneseItalic, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
-:is([style*="font:" i], [style*="font-family:" i]) :is(i, [style*="italic" i]) :is(.lang-text, span, bdi)[lang]:lang(ja),
-:is([style*="font:" i], [style*="font-family:" i]) :is(.lang-text, span, bdi)[lang]:lang(ja) :is(i, [style*="italic" i]) {
+:is([style*="font:" i], [style*="font-family:" i]) :is(i, em, [style*="italic" i]) [lang]:lang(ja),
+:is([style*="font:" i], [style*="font-family:" i]) [lang]:lang(ja):is(i, em, [style*="italic" i]),
+:is([style*="font:" i], [style*="font-family:" i]) [lang]:lang(ja) :is(i, em, [style*="italic" i]) {
     font-family: inherit;
 }
 

--- a/src/gadgets/site-styles/Gadget-site-styles.css
+++ b/src/gadgets/site-styles/Gadget-site-styles.css
@@ -283,7 +283,7 @@
     font-family: JapaneseItalic, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
-:is([style*="font:" i], [style*="font-family:" i]):is(i, em, [style*="italic" i]) [lang]:lang(ja),
+:is(i, em, [style*="italic" i]):is([style*="font:" i], [style*="font-family:" i]) [lang]:lang(ja),
 :is([style*="font:" i], [style*="font-family:" i]) :is(i, em, [style*="italic" i]) [lang]:lang(ja),
 :is([style*="font:" i], [style*="font-family:" i]) [lang]:lang(ja):is(i, em, [style*="italic" i]),
 :is([style*="font:" i], [style*="font-family:" i]) [lang]:lang(ja) :is(i, em, [style*="italic" i]) {


### PR DESCRIPTION
Resolves #1046

## Sourcery 总结

简化字体回退处理，并改进带语言标签内容中的日文斜体渲染。

错误修复：
- 扩展日文斜体样式，使其涵盖强调元素、直接带语言标签的元素，以及其他嵌套选择器模式。

增强功能：
- 简化标题和皮肤的 `font-family` 定义，同时保留日文 Gothic 和表情符号字体回退。
- 移除过时的语言元素字体重置和继承覆盖，因为现在不再需要本地化字体处理。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

简化字体回退处理，并改进带语言标签内容的日文斜体渲染。

错误修复：
- 扩展日文斜体字体样式的适用范围，涵盖强调元素、直接标记为日文的元素，以及其他嵌套选择器模式。

增强功能：
- 简化标题和皮肤的 `font-family` 定义，同时保留日文 Gothic 和表情符号回退字体。
- 移除过时的语言元素字体重置和继承覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

简化字体回退处理，并改进带语言标签内容的日文斜体渲染。

错误修复：
- 扩展日文斜体样式，使其涵盖强调元素、直接标记为日文的元素，以及其他嵌套选择器模式。

增强功能：
- 简化标题和皮肤的 `font-family` 定义，同时保留日文 Gothic 和表情符号回退字体。
- 移除过时的本地化语言字体重置和继承覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify font fallback handling and improve Japanese italic rendering for language-tagged content.

Bug Fixes:
- Broaden Japanese italic styling to cover emphasis elements, directly Japanese-tagged elements, and additional nested selector patterns.

Enhancements:
- Simplify heading and skin font-family definitions while retaining Japanese Gothic and emoji fallbacks.
- Remove obsolete localized-language font resets and inheritance overrides.

</details>

</details>

</details>