### PR TITLE
fix(Gadget/noteTA): scale conversion icon with surrounding text

### DIFF
--- a/src/gadgets/noteTA/Gadget-noteTA.css
+++ b/src/gadgets/noteTA/Gadget-noteTA.css
@@ -30,6 +30,12 @@
     display: block;
 }
 
+.noteTA-indicator-icon {
+    height: 1.5em;
+    width: auto;
+    vertical-align: middle;
+}
+
 /* 只有打开小工具才有的按钮动画, written by User:机智的小鱼君 */
 .noteTAViewer-button:hover {
     border-color: #36ad6a;

--- a/src/gadgets/noteTA/Gadget-noteTA.js
+++ b/src/gadgets/noteTA/Gadget-noteTA.js
@@ -287,7 +287,7 @@ const setupViewer = ($dom) => {
         $("#p-noteTA-moeskin > button").addClass("noteTAViewer-button");
     } else {
         const noteTAIndicator = $("[id^=mw-indicator-noteTA-]").hide();
-        const $noteTAIndicatorImg = noteTAIndicator.find("img").first().clone().css("height", "17.5px");
+        const $noteTAIndicatorImg = noteTAIndicator.find("img").first().clone().addClass("noteTA-indicator-icon");
         const $vectorVariantsDropdown = $("#vector-variants-dropdown");
         if ($vectorVariantsDropdown.length) {
             $trigger = $("<div/>", {


### PR DESCRIPTION
## Sourcery 摘要

错误修复：
- 根据周围文本调整 noteTA 转换指示器图标的大小，以确保其在不同上下文中的显示一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Scale the noteTA conversion indicator icon relative to surrounding text for consistent display across contexts.

</details>